### PR TITLE
Handled set fix

### DIFF
--- a/ranker/shared/ranker_obj.py
+++ b/ranker/shared/ranker_obj.py
@@ -109,18 +109,21 @@ class Ranker:
         knode_map = defaultdict(set)
         for nb in answer['node_bindings']:
             qnode_id = nb['qg_id']
-            knode_id = nb['kg_id']
-            rnode_id = (qnode_id, knode_id)
-            rnodes.add(rnode_id)
-            knode_map[knode_id].add(rnode_id)
-            if qnode_id in self.leaf_sets:
-                anchor_id = (f'{qnode_id}_anchor', '')
-                rnodes.add(anchor_id)
-                redges.append({
-                    'weight': 1e9,
-                    'source_id': rnode_id,
-                    'target_id': anchor_id
-                })
+            knode_ids = nb['kg_id']
+            if isinstance(knode_ids,str):
+                knode_ids = [ knode_ids ]
+            for knode_id in knode_ids:
+                rnode_id = (qnode_id, knode_id)
+                rnodes.add(rnode_id)
+                knode_map[knode_id].add(rnode_id)
+                if qnode_id in self.leaf_sets:
+                    anchor_id = (f'{qnode_id}_anchor', '')
+                    rnodes.add(anchor_id)
+                    redges.append({
+                        'weight': 1e9,
+                        'source_id': rnode_id,
+                        'target_id': anchor_id
+                    })
         rnodes = list(rnodes)
 
         # get "result" edges

--- a/tests/data/treatsSchizophreniaw.json
+++ b/tests/data/treatsSchizophreniaw.json
@@ -1,0 +1,13974 @@
+{
+  "query_graph": {
+    "nodes": [
+      {
+        "id": "a",
+        "curie": "MONDO:0005090",
+        "type": "disease"
+      },
+      {
+        "id": "b",
+        "type": "chemical_substance",
+        "set": true
+      },
+      {
+        "id": "extra_qn_0",
+        "type":  "disease"
+      }
+    ],
+    "edges": [
+      {
+        "id": "ab",
+        "source_id": "b",
+        "target_id": "a",
+        "type": "treats"
+      },
+      {
+        "id": "extra_qe_0",
+        "source_id": "b",
+        "target_id": "extra_qn_0"
+      }
+    ]
+  },
+  "knowledge_graph": {
+    "nodes": [
+      {
+        "id": "MONDO:0005090",
+        "type": [
+          "named_thing",
+          "disease",
+          "disease_or_phenotypic_feature"
+        ],
+        "synonyms": [
+          "schizophrenia",
+          "schizophrenia-1",
+          "schizoaffective disorder",
+          "schizophrenia with or without an affective disorder",
+          "schizophrenia; SCZD",
+          "SCZD"
+        ],
+        "name": "schizophrenia (disease)",
+        "equivalent_identifiers": [
+          "SNOMEDCT:268748000",
+          "SNOMEDCT:192322009",
+          "SNOMEDCT:83746006",
+          "SNOMEDCT:191549007",
+          "MESH:D012562",
+          "SNOMEDCT:191526005",
+          "NCIT:C3362",
+          "MESH:D012561",
+          "UMLS:C0154346",
+          "UMLS:C0154451",
+          "UMLS:C0154362",
+          "NCIT:C35270",
+          "UMLS:C0154454",
+          "UMLS:C1562670",
+          "UMLS:C0154388",
+          "UMLS:C0375158",
+          "UMLS:C0154342",
+          "SNOMEDCT:191528006",
+          "UMLS:C0338796",
+          "UMLS:C0270395",
+          "UMLS:C0154361",
+          "UMLS:C1542843",
+          "UMLS:C0154347",
+          "SNOMEDCT:51133006",
+          "UMLS:C0154345",
+          "UMLS:C4524147",
+          "UMLS:C0154340",
+          "NCIT:C35004",
+          "MEDDRA:10061040",
+          "SNOMEDCT:111483008",
+          "SNOMEDCT:191540006",
+          "NCIT:C35184",
+          "UMLS:C0154452",
+          "UMLS:C0863109",
+          "UMLS:C0154450",
+          "NCIT:C35183",
+          "UMLS:C0154349",
+          "SNOMEDCT:29599000",
+          "UMLS:C0270406",
+          "UMLS:C1656427",
+          "SNOMEDCT:416340002",
+          "SNOMEDCT:58214004",
+          "NCIT:C35007",
+          "SNOMEDCT:154870000",
+          "UMLS:C0853931",
+          "UMLS:C0154357",
+          "UMLS:C0029838",
+          "MONDO:0005090",
+          "DOID:5419",
+          "SNOMEDCT:268626003",
+          "UMLS:C0857501",
+          "SNOMEDCT:191535003",
+          "MESH:D012559",
+          "UMLS:C0154382",
+          "UMLS:C0154364",
+          "UMLS:C0221520",
+          "UMLS:C0270390",
+          "UMLS:C0154381",
+          "UMLS:C0036346",
+          "SNOMEDCT:16990005",
+          "UMLS:C0036347",
+          "UMLS:C0154373",
+          "SNOMEDCT:31373002",
+          "UMLS:C0270408",
+          "SNOMEDCT:154869001",
+          "UMLS:C0036341",
+          "SNOMEDCT:191534004",
+          "UMLS:C0338793",
+          "UMLS:C0375157",
+          "SNOMEDCT:192324005",
+          "UMLS:C4049474",
+          "SNOMEDCT:35252006",
+          "UMLS:C0154344",
+          "UMLS:C0221765",
+          "UMLS:C0154339",
+          "SNOMEDCT:4926007",
+          "SNOMEDCT:154867004",
+          "SNOMEDCT:192327003",
+          "UMLS:C0154363",
+          "UMLS:C0154374",
+          "UMLS:C0154380",
+          "OMIM:181500",
+          "SNOMEDCT:154866008",
+          "UMLS:C0154387",
+          "UMLS:C0154352",
+          "UMLS:C0154358",
+          "SNOMEDCT:192320001",
+          "SNOMEDCT:111484002",
+          "UMLS:C0154360",
+          "SNOMEDCT:71103003",
+          "UMLS:C0154384",
+          "SNOMEDCT:191529003",
+          "UMLS:C0154453",
+          "UMLS:C4049473",
+          "SNOMEDCT:231484006",
+          "NCIT:C35269",
+          "UMLS:C0030484",
+          "UMLS:C0270403",
+          "NCIT:C35185",
+          "SNOMEDCT:76566000",
+          "UMLS:C3544321",
+          "UMLS:C0154356",
+          "UMLS:C0036351",
+          "HP:0100753",
+          "UMLS:C0270381",
+          "SNOMEDCT:191533005",
+          "UMLS:C0154341",
+          "UMLS:C1535118",
+          "SNOMEDCT:191699003",
+          "SNOMEDCT:191687005",
+          "SNOMEDCT:26025008",
+          "UMLS:C0154343",
+          "MEDDRA:10039626",
+          "NCIT:C35721",
+          "NCIT:C35005",
+          "UMLS:C0154351",
+          "SNOMEDCT:192325006",
+          "UMLS:C1536217",
+          "SNOMEDCT:191579000",
+          "NCIT:C94370",
+          "UMLS:C0154372",
+          "UMLS:C0154383",
+          "UMLS:C0154354",
+          "SNOMEDCT:191541005",
+          "UMLS:C0392322",
+          "UMLS:C0154350",
+          "SNOMEDCT:191527001",
+          "SNOMEDCT:26472000",
+          "UMLS:C0270384"
+        ],
+        "omnicorp_article_count": 138621
+      },
+      {
+        "id": "CHEBI:65173",
+        "type": [
+          "named_thing",
+          "chemical_substance"
+        ],
+        "synonyms": [
+          "1-(4-{3-[4-(6-fluoro-1,2-benzoxazol-3-yl)piperidin-1-yl]propoxy}-3-methoxyphenyl)ethanone",
+          "1-[4-[3-[4-(6-fluoro-1,2-benzisoxazol-3-yl)-1- piperidinyl]propoxy]-3-methoxyphenyl]ethanone",
+          "4'-(3-(4-(6-fluoro-1,2-benzisoxazol-3-yl)piperidino)propoxy)-3'-methoxyacetophenone",
+          "Fanapt",
+          "Fanapta",
+          "iloperidona",
+          "iloperidone",
+          "iloperidonum",
+          "Zomaril"
+        ],
+        "name": "iloperidone",
+        "equivalent_identifiers": [
+          "CHEBI:65173",
+          "UNII:VPO7KJ050N",
+          "CHEMBL.COMPOUND:CHEMBL14376",
+          "GTOPDB:87",
+          "DRUGBANK:DB04946",
+          "INCHIKEY:SIVSOFOFVRLIPH-UHFFFAOYSA-N",
+          "MESH:C081732",
+          "PUBCHEM:71360"
+        ],
+        "omnicorp_article_count": 202
+      },
+      {
+        "id": "CHEBI:8707",
+        "type": [
+          "named_thing",
+          "chemical_substance"
+        ],
+        "synonyms": [
+          "2-[2-(4-dibenzo[b,f][1,4]thiazepin-11-ylpiperazin-1-yl)ethoxy]ethanol",
+          "Quetiapine",
+          "2-[2-(4-Dibenzo[b,f][1,4]thiazepin-11-yl-1-piperazinyl)ethoxy]ethanol",
+          "quetiapina",
+          "quetiapine",
+          "quetiapinum"
+        ],
+        "name": "quetiapine",
+        "equivalent_identifiers": [
+          "UNII:BGL0JSY5SI",
+          "MESH:C069541",
+          "CHEMBL.COMPOUND:CHEMBL716",
+          "CHEBI:8707",
+          "GTOPDB:50",
+          "DRUGBANK:DB01224",
+          "PUBCHEM:5002",
+          "INCHIKEY:ZKLZSAACDZEQLJ-HXUWFJFHSA-N",
+          "HMDB:HMDB0005021",
+          "KEGG.COMPOUND:C07397"
+        ],
+        "omnicorp_article_count": 5484
+      },
+      {
+        "id": "CHEBI:3766",
+        "type": [
+          "named_thing",
+          "chemical_substance"
+        ],
+        "synonyms": [
+          "8-chloro-11-(4-methylpiperazin-1-yl)-5H-dibenzo[b,e][1,4]diazepine",
+          "Clozapine",
+          "Clozapin",
+          "clozapina",
+          "clozapine",
+          "clozapinum"
+        ],
+        "name": "clozapine",
+        "equivalent_identifiers": [
+          "KEGG.COMPOUND:C06924",
+          "CHEBI:3766",
+          "CHEMBL.COMPOUND:CHEMBL42",
+          "MESH:D003024",
+          "GTOPDB:38",
+          "UNII:J60AR2IKIC",
+          "PUBCHEM:135398737",
+          "HMDB:HMDB0014507",
+          "INCHIKEY:APSCTLSVGWMNTN-IAGOWNOFSA-N",
+          "DRUGBANK:DB00363"
+        ],
+        "omnicorp_article_count": 12398
+      },
+      {
+        "id": "CHEBI:7735",
+        "type": [
+          "named_thing",
+          "chemical_substance"
+        ],
+        "synonyms": [
+          "2-methyl-4-(4-methylpiperazin-1-yl)-10H-thieno[2,3-b][1,5]benzodiazepine",
+          "Olanzapine",
+          "olanzapina",
+          "olanzapine",
+          "olanzapinum",
+          "Zyprexa"
+        ],
+        "name": "olanzapine",
+        "equivalent_identifiers": [
+          "PUBCHEM:135398745",
+          "INCHIKEY:JQQNLWJEKGFILV-UHFFFAOYSA-N",
+          "KEGG.COMPOUND:C07322",
+          "MESH:D000077152",
+          "CHEMBL.COMPOUND:CHEMBL715",
+          "UNII:N7U69T4SZR",
+          "CHEBI:7735",
+          "MESH:C076029",
+          "DRUGBANK:DB00334",
+          "HMDB:HMDB0005012"
+        ],
+        "omnicorp_article_count": 9015
+      },
+      {
+        "id": "CHEBI:10119",
+        "type": [
+          "named_thing",
+          "chemical_substance"
+        ],
+        "synonyms": [
+          "5-{2-[4-(1,2-benzothiazol-3-yl)piperazin-1-yl]ethyl}-6-chloro-1,3-dihydro-2H-indol-2-one",
+          "Ziprasidone",
+          "ziprasidona",
+          "ziprasidone",
+          "ziprasidonum"
+        ],
+        "name": "ziprasidone",
+        "equivalent_identifiers": [
+          "CHEBI:10119",
+          "KEGG.COMPOUND:C07568",
+          "CHEMBL.COMPOUND:CHEMBL708",
+          "GTOPDB:59",
+          "INCHIKEY:QRGLOHALUOQSDT-UHFFFAOYSA-N",
+          "DRUGBANK:DB00246",
+          "PUBCHEM:60854",
+          "MESH:C092292",
+          "UNII:6UKA5VEJ6X",
+          "HMDB:HMDB0014391"
+        ],
+        "omnicorp_article_count": 1963
+      },
+      {
+        "id": "CHEBI:70735",
+        "type": [
+          "named_thing",
+          "chemical_substance"
+        ],
+        "synonyms": [
+          "(3aR,4S,7R,7aS)-2-{[(1R,2R)-2-{[4-(1,2-benzothiazol-3-yl)piperazin-1-yl]methyl}cyclohexyl]methyl}hexahydro-1H-4,7-methanoisoindole-1,3(2H)-dione",
+          "lurasidona",
+          "lurasidone",
+          "lurasidonum"
+        ],
+        "name": "lurasidone",
+        "equivalent_identifiers": [
+          "GTOPDB:7461",
+          "UNII:22IC88528T",
+          "MESH:C525644",
+          "INCHIKEY:NZESJOKORMSILA-ZARYIDLBSA-N",
+          "PUBCHEM:213046",
+          "CHEMBL.COMPOUND:CHEMBL1237021",
+          "DRUGBANK:DB08815",
+          "CHEBI:70735"
+        ],
+        "omnicorp_article_count": 396
+      },
+      {
+        "id": "CHEBI:31236",
+        "type": [
+          "named_thing",
+          "chemical_substance"
+        ],
+        "synonyms": [
+          "7-{4-[4-(2,3-dichlorophenyl)piperazin-1-yl]butoxy}-3,4-dihydroquinolin-2(1H)-one",
+          "aripiprazole",
+          "Aripiprazole",
+          "Abilify",
+          "Abilitat",
+          "aripiprazol",
+          "aripiprazolum"
+        ],
+        "name": "aripiprazole",
+        "equivalent_identifiers": [
+          "DRUGBANK:DB01238",
+          "CHEMBL.COMPOUND:CHEMBL1112",
+          "GTOPDB:34",
+          "INCHIKEY:HBRQZJDFQWHINU-SELJRJPRSA-N",
+          "CHEBI:31236",
+          "MESH:D000068180",
+          "UNII:82VFR53I78",
+          "KEGG.COMPOUND:C12564",
+          "PUBCHEM:60795",
+          "MESH:C094645",
+          "HMDB:HMDB0005042"
+        ],
+        "omnicorp_article_count": 4052
+      },
+      {
+        "id": "CHEBI:8871",
+        "type": [
+          "named_thing",
+          "chemical_substance"
+        ],
+        "synonyms": [
+          "3-{2-[4-(6-fluoro-1,2-benzisoxazol-3-yl)piperidin-1-yl]ethyl}-2-methyl-6,7,8,9-tetrahydro-4H-pyrido[1,2-a]pyrimidin-4-one",
+          "risperidone",
+          "Risperdal",
+          "risperidona",
+          "risperidonum",
+          "Risperin",
+          "Rispolept",
+          "Rispolin",
+          "Sequinan"
+        ],
+        "name": "risperidone",
+        "equivalent_identifiers": [
+          "CHEMBL.COMPOUND:CHEMBL85",
+          "PUBCHEM:5073",
+          "UNII:L6UH7ZF8HC",
+          "GTOPDB:96",
+          "INCHIKEY:ICKPMTNGWVNOGC-UHFFFAOYSA-N",
+          "HMDB:HMDB0005020",
+          "DRUGBANK:DB00734",
+          "CHEBI:8871",
+          "MESH:D018967"
+        ],
+        "omnicorp_article_count": 9845
+      },
+      {
+        "id": "CHEBI:5613",
+        "type": [
+          "named_thing",
+          "chemical_substance"
+        ],
+        "synonyms": [
+          "4-[4-(4-chlorophenyl)-4-hydroxypiperidin-1-yl]-1-(4-fluorophenyl)butan-1-one",
+          "1-(3-p-fluorobenzoylpropyl)-4-p-chlorophenyl-4-hydroxypiperidine",
+          "4-(4-(para-chlorophenyl)-4-hydroxypiperidino)-4'-fluorobutyrophenone",
+          "4-[4-(4-chlorophenyl)-4-hydroxy-1-piperidyl]-1-(4-fluorophenyl)-butan-1-one",
+          "4'-fluoro-4-(4-(p-chlorophenyl)-4-hydroxypiperidinyl)butyrophenone",
+          "4'-fluoro-4-(4-hydroxy-4-(4'-chlorophenyl)piperidino)butyrophenone",
+          "gamma-(4-(p-chlorophenyl)-4-hydroxpiperidino)-p-fluorbutyrophenone",
+          "Haldol",
+          "haloperidol",
+          "haloperidolum"
+        ],
+        "name": "haloperidol",
+        "equivalent_identifiers": [
+          "KEGG.COMPOUND:C01814",
+          "CHEMBL.COMPOUND:CHEMBL54",
+          "UNII:J6292F8L3D",
+          "PUBCHEM:3559",
+          "MESH:D006220",
+          "DRUGBANK:DB00502",
+          "HMDB:HMDB0014645",
+          "INCHIKEY:RTWGXFRLCDXCRX-OJSVXGLKSA-N",
+          "CHEBI:5613",
+          "GTOPDB:86"
+        ],
+        "omnicorp_article_count": 22056
+      },
+      {
+        "id": "CHEBI:31981",
+        "type": [
+          "named_thing",
+          "biological_entity",
+          "chemical_substance",
+          "molecular_entity"
+        ],
+        "name": "periciazine",
+        "equivalent_identifiers": [
+          "CHEMBL.COMPOUND:CHEMBL251940",
+          "INCHIKEY:YOKUDVNJYHCXIK-UHFFFAOYSA-N",
+          "MESH:C084584",
+          "HMDB:HMDB0015546",
+          "UNII:3405M6FD73",
+          "DRUGBANK:DB01608",
+          "PUBCHEM:4747",
+          "GTOPDB:9216",
+          "CHEBI:31981"
+        ],
+        "omnicorp_article_count": 41
+      },
+      {
+        "id": "MESH:D014282",
+        "type": [
+          "named_thing",
+          "biological_entity",
+          "chemical_substance",
+          "molecular_entity"
+        ],
+        "name": "Trihexyphenidyl",
+        "equivalent_identifiers": [
+          "MESH:D014282",
+          "UNII:6RC5V8B7PO"
+        ],
+        "omnicorp_article_count": 909
+      },
+      {
+        "id": "MESH:D000068882",
+        "type": [
+          "named_thing",
+          "biological_entity",
+          "chemical_substance",
+          "molecular_entity"
+        ],
+        "name": "Paliperidone Palmitate",
+        "equivalent_identifiers": [
+          "MESH:D000068882",
+          "MESH:C548956",
+          "UNII:R8P8USM8FR"
+        ],
+        "omnicorp_article_count": 0
+      },
+      {
+        "id": "MESH:D011352",
+        "type": [
+          "named_thing",
+          "biological_entity",
+          "chemical_substance",
+          "molecular_entity"
+        ],
+        "name": "Procyclidine",
+        "equivalent_identifiers": [
+          "MESH:D011352",
+          "UNII:C6QE1Q1TKR"
+        ],
+        "omnicorp_article_count": 214
+      },
+      {
+        "id": "MESH:D013469",
+        "type": [
+          "named_thing",
+          "biological_entity",
+          "chemical_substance",
+          "molecular_entity"
+        ],
+        "name": "Sulpiride",
+        "equivalent_identifiers": [
+          "MESH:D013469",
+          "UNII:7MNE9M8287"
+        ],
+        "omnicorp_article_count": 3926
+      },
+      {
+        "id": "MESH:D011433",
+        "type": [
+          "named_thing",
+          "biological_entity",
+          "chemical_substance",
+          "molecular_entity"
+        ],
+        "name": "Propranolol",
+        "equivalent_identifiers": [
+          "MESH:D011433",
+          "UNII:9Y8NXQ24VQ"
+        ],
+        "omnicorp_article_count": 32174
+      },
+      {
+        "id": "MESH:D008972",
+        "type": [
+          "named_thing",
+          "biological_entity",
+          "chemical_substance",
+          "molecular_entity"
+        ],
+        "name": "Molindone",
+        "equivalent_identifiers": [
+          "MESH:D008972",
+          "UNII:RT3Y3QMF8N"
+        ],
+        "omnicorp_article_count": 141
+      },
+      {
+        "id": "CHEMBL.COMPOUND:CHEMBL218166",
+        "type": [
+          "named_thing",
+          "biological_entity",
+          "chemical_substance",
+          "molecular_entity"
+        ],
+        "name": "BIFEPRUNOX",
+        "equivalent_identifiers": [
+          "PUBCHEM:208951",
+          "CHEMBL.COMPOUND:CHEMBL218166",
+          "MESH:C509981",
+          "INCHIKEY:ZZEABFFKPGYSDC-CEXWTWQISA-N",
+          "UNII:AP69E83Z79",
+          "DRUGBANK:DB04888"
+        ],
+        "omnicorp_article_count": 0
+      },
+      {
+        "id": "MESH:C515050",
+        "type": [
+          "named_thing",
+          "biological_entity",
+          "chemical_substance",
+          "molecular_entity"
+        ],
+        "name": "zopiclone",
+        "equivalent_identifiers": [
+          "UNII:03A5ORL08Q",
+          "MESH:C515050"
+        ],
+        "omnicorp_article_count": 687
+      },
+      {
+        "id": "CHEBI:135778",
+        "type": [
+          "named_thing",
+          "biological_entity",
+          "chemical_substance",
+          "molecular_entity"
+        ],
+        "synonyms": [
+          "clocapramine HCl",
+          "clocapramine hydrochloride",
+          "clocarpramine"
+        ],
+        "name": "clocapramine",
+        "equivalent_identifiers": [
+          "UNII:6EEL1GB72K",
+          "CHEBI:135778",
+          "DRUGBANK:DB09003",
+          "INCHIKEY:KRCTXIMBJOXIRC-AWEZNQCLSA-N",
+          "MESH:C000449",
+          "CHEMBL.COMPOUND:CHEMBL2104103",
+          "PUBCHEM:2793"
+        ],
+        "omnicorp_article_count": 23
+      },
+      {
+        "id": "MESH:C060342",
+        "type": [
+          "named_thing",
+          "biological_entity",
+          "chemical_substance",
+          "molecular_entity"
+        ],
+        "name": "clopenthixol acetate ester",
+        "equivalent_identifiers": [
+          "UNII:0A4EBG0F53",
+          "MESH:C060342"
+        ],
+        "omnicorp_article_count": 36
+      },
+      {
+        "id": "MESH:D012906",
+        "type": [
+          "named_thing",
+          "biological_entity",
+          "chemical_substance",
+          "molecular_entity"
+        ],
+        "name": "Smoke",
+        "equivalent_identifiers": [
+          "MESH:D012906"
+        ],
+        "omnicorp_article_count": 8183
+      },
+      {
+        "id": "MESH:D000077408",
+        "type": [
+          "named_thing",
+          "biological_entity",
+          "chemical_substance",
+          "molecular_entity"
+        ],
+        "name": "Modafinil",
+        "equivalent_identifiers": [
+          "UNII:R3UK8X3U3D",
+          "MESH:C048833",
+          "MESH:D000077408"
+        ],
+        "omnicorp_article_count": 0
+      },
+      {
+        "id": "MESH:C007761",
+        "type": [
+          "named_thing",
+          "biological_entity",
+          "chemical_substance",
+          "molecular_entity"
+        ],
+        "name": "flupenthixol decanoate",
+        "equivalent_identifiers": [
+          "MESH:C007761",
+          "UNII:3B2FE28C1W"
+        ],
+        "omnicorp_article_count": 95
+      },
+      {
+        "id": "MESH:D012436",
+        "type": [
+          "named_thing",
+          "biological_entity",
+          "chemical_substance",
+          "molecular_entity"
+        ],
+        "name": "S-Adenosylmethionine",
+        "equivalent_identifiers": [
+          "UNII:7LP2MPO46S",
+          "MESH:D012436"
+        ],
+        "omnicorp_article_count": 5401
+      },
+      {
+        "id": "CHEMBL.COMPOUND:CHEMBL2105481",
+        "type": [
+          "named_thing",
+          "biological_entity",
+          "chemical_substance",
+          "molecular_entity"
+        ],
+        "name": "ZETIDOLINE",
+        "equivalent_identifiers": [
+          "INCHIKEY:QSFREBZMBNRGOK-UHFFFAOYSA-N",
+          "CHEMBL.COMPOUND:CHEMBL2105481",
+          "UNII:3B5J9TG94X",
+          "MESH:C027277",
+          "PUBCHEM:72155"
+        ],
+        "omnicorp_article_count": 0
+      },
+      {
+        "id": "MESH:D000077582",
+        "type": [
+          "named_thing",
+          "biological_entity",
+          "chemical_substance",
+          "molecular_entity"
+        ],
+        "name": "Amisulpride",
+        "equivalent_identifiers": [
+          "MESH:D000077582",
+          "UNII:8110R61I4U"
+        ],
+        "omnicorp_article_count": 698
+      },
+      {
+        "id": "CHEBI:64050",
+        "type": [
+          "named_thing",
+          "biological_entity",
+          "chemical_substance",
+          "molecular_entity"
+        ],
+        "name": "N-desmethylclozapine",
+        "equivalent_identifiers": [
+          "UNII:1I9001LWY8",
+          "HMDB:HMDB0060536",
+          "PUBCHEM:135409468",
+          "CHEBI:64050",
+          "CHEMBL.COMPOUND:CHEMBL845",
+          "MESH:C058272",
+          "INCHIKEY:GCOHVGCNKUNLJF-JRFVFWCSSA-N"
+        ],
+        "omnicorp_article_count": 415
+      },
+      {
+        "id": "MESH:D005473",
+        "type": [
+          "named_thing",
+          "biological_entity",
+          "chemical_substance",
+          "molecular_entity"
+        ],
+        "name": "Fluoxetine",
+        "equivalent_identifiers": [
+          "UNII:01K63SUP8D",
+          "MESH:D005473"
+        ],
+        "omnicorp_article_count": 8952
+      },
+      {
+        "id": "CHEMBL.COMPOUND:CHEMBL2106135",
+        "type": [
+          "named_thing",
+          "biological_entity",
+          "chemical_substance",
+          "molecular_entity"
+        ],
+        "name": "BROMPERIDOL",
+        "equivalent_identifiers": [
+          "MESH:C077144",
+          "CHEMBL.COMPOUND:CHEMBL2106135",
+          "UNII:73LG72M4LV",
+          "PUBCHEM:156321",
+          "INCHIKEY:LPXJVJPXCNRZNB-OAQYLSRUSA-N"
+        ],
+        "omnicorp_article_count": 0
+      },
+      {
+        "id": "MESH:D008653",
+        "type": [
+          "named_thing",
+          "biological_entity",
+          "chemical_substance",
+          "molecular_entity"
+        ],
+        "name": "Mesoridazine",
+        "equivalent_identifiers": [
+          "MESH:D008653",
+          "UNII:5XE4NWM740"
+        ],
+        "omnicorp_article_count": 128
+      },
+      {
+        "id": "MESH:D011398",
+        "type": [
+          "named_thing",
+          "biological_entity",
+          "chemical_substance",
+          "molecular_entity"
+        ],
+        "name": "Promethazine",
+        "equivalent_identifiers": [
+          "MESH:D011398",
+          "UNII:FF28EJQ494"
+        ],
+        "omnicorp_article_count": 3001
+      },
+      {
+        "id": "MESH:D008140",
+        "type": [
+          "named_thing",
+          "biological_entity",
+          "chemical_substance",
+          "molecular_entity"
+        ],
+        "name": "Lorazepam",
+        "equivalent_identifiers": [
+          "MESH:D008140",
+          "UNII:O26FZP769L"
+        ],
+        "omnicorp_article_count": 2836
+      },
+      {
+        "id": "MESH:C100234",
+        "type": [
+          "named_thing",
+          "biological_entity",
+          "chemical_substance",
+          "molecular_entity"
+        ],
+        "name": "benzquinamide",
+        "equivalent_identifiers": [
+          "UNII:0475EA27Q3",
+          "MESH:C100234"
+        ],
+        "omnicorp_article_count": 35
+      },
+      {
+        "id": "MESH:D013881",
+        "type": [
+          "named_thing",
+          "biological_entity",
+          "chemical_substance",
+          "molecular_entity"
+        ],
+        "name": "Thioridazine",
+        "equivalent_identifiers": [
+          "UNII:N3D6TG58NI",
+          "MESH:D013881"
+        ],
+        "omnicorp_article_count": 2366
+      },
+      {
+        "id": "MESH:C030265",
+        "type": [
+          "named_thing",
+          "biological_entity",
+          "chemical_substance",
+          "molecular_entity"
+        ],
+        "name": "nemonapride",
+        "equivalent_identifiers": [
+          "UNII:Q88T5P3444",
+          "MESH:C030265"
+        ],
+        "omnicorp_article_count": 244
+      },
+      {
+        "id": "MESH:D001712",
+        "type": [
+          "named_thing",
+          "biological_entity",
+          "chemical_substance",
+          "molecular_entity"
+        ],
+        "name": "Biperiden",
+        "equivalent_identifiers": [
+          "UNII:0FRP6G56LD",
+          "MESH:D001712"
+        ],
+        "omnicorp_article_count": 456
+      },
+      {
+        "id": "MESH:D000069470",
+        "type": [
+          "named_thing",
+          "biological_entity",
+          "chemical_substance",
+          "molecular_entity"
+        ],
+        "name": "Venlafaxine Hydrochloride",
+        "equivalent_identifiers": [
+          "MESH:D000069470",
+          "UNII:7D7RX5A8MO"
+        ],
+        "omnicorp_article_count": 2511
+      },
+      {
+        "id": "CHEBI:92293",
+        "type": [
+          "named_thing",
+          "biological_entity",
+          "chemical_substance",
+          "molecular_entity"
+        ],
+        "name": "1-[10-[3-[4-(2-hydroxyethyl)-1-piperidinyl]propyl]-2-phenothiazinyl]ethanone",
+        "equivalent_identifiers": [
+          "UNII:KL6248WNW4",
+          "CHEBI:92293",
+          "INCHIKEY:RBIFNGAZHMWSFC-UHFFFAOYSA-N",
+          "CHEMBL.COMPOUND:CHEMBL1584",
+          "MESH:C067601",
+          "PUBCHEM:19675"
+        ],
+        "omnicorp_article_count": 9
+      },
+      {
+        "id": "MESH:C522667",
+        "type": [
+          "named_thing",
+          "biological_entity",
+          "chemical_substance",
+          "molecular_entity"
+        ],
+        "name": "Asenapine",
+        "equivalent_identifiers": [
+          "UNII:JKZ19V908O",
+          "MESH:C522667"
+        ],
+        "omnicorp_article_count": 215
+      },
+      {
+        "id": "CHEBI:34605",
+        "type": [
+          "named_thing",
+          "biological_entity",
+          "chemical_substance",
+          "molecular_entity"
+        ],
+        "synonyms": [
+          "CX-516"
+        ],
+        "name": "CX-516",
+        "equivalent_identifiers": [
+          "KEGG.COMPOUND:C13675",
+          "GTOPDB:4165",
+          "INCHIKEY:WRPPYCQXFUXOQL-IYNIXLDNSA-N",
+          "UNII:Z5QU38B4V9",
+          "DRUGBANK:DB06247",
+          "CHEMBL.COMPOUND:CHEMBL136800",
+          "PUBCHEM:148184",
+          "CHEBI:34605",
+          "MESH:C097396"
+        ],
+        "omnicorp_article_count": 58
+      },
+      {
+        "id": "MESH:D003990",
+        "type": [
+          "named_thing",
+          "biological_entity",
+          "chemical_substance",
+          "molecular_entity"
+        ],
+        "name": "Dibenzoxepins",
+        "equivalent_identifiers": [
+          "MESH:D003990"
+        ],
+        "omnicorp_article_count": 531
+      },
+      {
+        "id": "MONDO:0004985",
+        "type": [
+          "named_thing",
+          "biological_entity",
+          "disease",
+          "disease_or_phenotypic_feature"
+        ],
+        "omnicorp_article_count": 49709
+      },
+      {
+        "id": "MONDO:0011552",
+        "type": [
+          "named_thing",
+          "biological_entity",
+          "disease",
+          "disease_or_phenotypic_feature"
+        ],
+        "omnicorp_article_count": 2536
+      },
+      {
+        "id": "MONDO:0019790",
+        "type": [
+          "named_thing",
+          "biological_entity",
+          "disease",
+          "disease_or_phenotypic_feature"
+        ],
+        "omnicorp_article_count": 4572
+      },
+      {
+        "id": "MONDO:0005804",
+        "type": [
+          "named_thing",
+          "biological_entity",
+          "disease",
+          "disease_or_phenotypic_feature"
+        ],
+        "omnicorp_article_count": 6811
+      },
+      {
+        "id": "MONDO:0006731",
+        "type": [
+          "named_thing",
+          "biological_entity",
+          "disease",
+          "disease_or_phenotypic_feature"
+        ],
+        "omnicorp_article_count": 50556
+      },
+      {
+        "id": "MONDO:0005466",
+        "type": [
+          "named_thing",
+          "biological_entity",
+          "disease",
+          "disease_or_phenotypic_feature"
+        ],
+        "omnicorp_article_count": 4912
+      },
+      {
+        "id": "MONDO:0001220",
+        "type": [
+          "named_thing",
+          "biological_entity",
+          "disease",
+          "disease_or_phenotypic_feature"
+        ],
+        "omnicorp_article_count": 6837
+      },
+      {
+        "id": "MONDO:0000947",
+        "type": [
+          "named_thing",
+          "biological_entity",
+          "disease",
+          "disease_or_phenotypic_feature"
+        ],
+        "omnicorp_article_count": 10029
+      },
+      {
+        "id": "MONDO:0001821",
+        "type": [
+          "named_thing",
+          "biological_entity",
+          "disease",
+          "disease_or_phenotypic_feature"
+        ],
+        "omnicorp_article_count": 458
+      },
+      {
+        "id": "MONDO:0003996",
+        "type": [
+          "named_thing",
+          "biological_entity",
+          "disease",
+          "disease_or_phenotypic_feature"
+        ],
+        "omnicorp_article_count": 5884
+      },
+      {
+        "id": "MONDO:0011728",
+        "type": [
+          "named_thing",
+          "biological_entity",
+          "disease",
+          "disease_or_phenotypic_feature"
+        ],
+        "omnicorp_article_count": 2167
+      },
+      {
+        "id": "HP:0005986",
+        "type": [
+          "named_thing",
+          "biological_entity",
+          "disease_or_phenotypic_feature",
+          "phenotypic_feature"
+        ],
+        "omnicorp_article_count": 24938
+      },
+      {
+        "id": "MONDO:0010096",
+        "type": [
+          "named_thing",
+          "biological_entity",
+          "disease",
+          "disease_or_phenotypic_feature"
+        ],
+        "omnicorp_article_count": 4232
+      },
+      {
+        "id": "MONDO:0002442",
+        "type": [
+          "named_thing",
+          "biological_entity",
+          "disease",
+          "disease_or_phenotypic_feature"
+        ],
+        "omnicorp_article_count": 8842
+      },
+      {
+        "id": "NCBIGene:3005",
+        "type": [
+          "named_thing",
+          "biological_entity",
+          "molecular_entity",
+          "gene",
+          "gene_or_gene_product",
+          "macromolecular_machine",
+          "genomic_entity"
+        ],
+        "omnicorp_article_count": 0
+      },
+      {
+        "id": "MONDO:0004745",
+        "type": [
+          "named_thing",
+          "biological_entity",
+          "disease",
+          "disease_or_phenotypic_feature"
+        ],
+        "omnicorp_article_count": 2976
+      },
+      {
+        "id": "MONDO:0001442",
+        "type": [
+          "named_thing",
+          "biological_entity",
+          "disease",
+          "disease_or_phenotypic_feature"
+        ],
+        "omnicorp_article_count": 3194
+      },
+      {
+        "id": "MONDO:0001484",
+        "type": [
+          "named_thing",
+          "biological_entity",
+          "disease",
+          "disease_or_phenotypic_feature"
+        ],
+        "omnicorp_article_count": 4724
+      },
+      {
+        "id": "MONDO:0002025",
+        "type": [
+          "named_thing",
+          "biological_entity",
+          "disease",
+          "disease_or_phenotypic_feature"
+        ],
+        "omnicorp_article_count": 236885
+      },
+      {
+        "id": "MONDO:0016058",
+        "type": [
+          "named_thing",
+          "biological_entity",
+          "disease",
+          "disease_or_phenotypic_feature"
+        ],
+        "omnicorp_article_count": 215
+      },
+      {
+        "id": "UMLS:C3665587",
+        "type": [
+          "named_thing",
+          "biological_entity",
+          "disease",
+          "disease_or_phenotypic_feature"
+        ],
+        "omnicorp_article_count": 0
+      },
+      {
+        "id": "MONDO:0005478",
+        "type": [
+          "named_thing",
+          "biological_entity",
+          "disease",
+          "disease_or_phenotypic_feature"
+        ],
+        "omnicorp_article_count": 4730
+      },
+      {
+        "id": "MONDO:0045057",
+        "type": [
+          "named_thing",
+          "biological_entity",
+          "disease",
+          "disease_or_phenotypic_feature"
+        ],
+        "omnicorp_article_count": 58454
+      },
+      {
+        "id": "MONDO:0024290",
+        "type": [
+          "named_thing",
+          "biological_entity",
+          "disease",
+          "disease_or_phenotypic_feature"
+        ],
+        "omnicorp_article_count": 5308
+      },
+      {
+        "id": "MONDO:0004901",
+        "type": [
+          "named_thing",
+          "biological_entity",
+          "disease",
+          "disease_or_phenotypic_feature"
+        ],
+        "omnicorp_article_count": 19384
+      },
+      {
+        "id": "MONDO:0006966",
+        "type": [
+          "named_thing",
+          "biological_entity",
+          "disease",
+          "disease_or_phenotypic_feature"
+        ],
+        "omnicorp_article_count": 4615
+      },
+      {
+        "id": "MONDO:0003785",
+        "type": [
+          "named_thing",
+          "biological_entity",
+          "disease",
+          "disease_or_phenotypic_feature"
+        ],
+        "omnicorp_article_count": 22625
+      },
+      {
+        "id": "MONDO:0005146",
+        "type": [
+          "named_thing",
+          "biological_entity",
+          "disease",
+          "disease_or_phenotypic_feature"
+        ],
+        "omnicorp_article_count": 40461
+      },
+      {
+        "id": "HP:0001662",
+        "type": [
+          "named_thing",
+          "biological_entity",
+          "disease_or_phenotypic_feature",
+          "phenotypic_feature"
+        ],
+        "omnicorp_article_count": 25388
+      },
+      {
+        "id": "MONDO:0005640",
+        "type": [
+          "named_thing",
+          "biological_entity",
+          "disease",
+          "disease_or_phenotypic_feature"
+        ],
+        "omnicorp_article_count": 721
+      },
+      {
+        "id": "MONDO:0002265",
+        "type": [
+          "named_thing",
+          "biological_entity",
+          "disease",
+          "disease_or_phenotypic_feature"
+        ],
+        "omnicorp_article_count": 12561
+      },
+      {
+        "id": "MONDO:0005395",
+        "type": [
+          "named_thing",
+          "biological_entity",
+          "disease",
+          "disease_or_phenotypic_feature"
+        ],
+        "omnicorp_article_count": 26956
+      },
+      {
+        "id": "MONDO:0005359",
+        "type": [
+          "named_thing",
+          "biological_entity",
+          "disease",
+          "disease_or_phenotypic_feature"
+        ],
+        "omnicorp_article_count": 29428
+      },
+      {
+        "id": "MONDO:0003233",
+        "type": [
+          "named_thing",
+          "biological_entity",
+          "disease",
+          "disease_or_phenotypic_feature"
+        ],
+        "omnicorp_article_count": 24740
+      },
+      {
+        "id": "MONDO:0002050",
+        "type": [
+          "named_thing",
+          "biological_entity",
+          "disease",
+          "disease_or_phenotypic_feature"
+        ],
+        "omnicorp_article_count": 390484
+      },
+      {
+        "id": "MONDO:0005485",
+        "type": [
+          "named_thing",
+          "biological_entity",
+          "disease",
+          "disease_or_phenotypic_feature"
+        ],
+        "omnicorp_article_count": 69360
+      },
+      {
+        "id": "MONDO:0005469",
+        "type": [
+          "named_thing",
+          "biological_entity",
+          "disease",
+          "disease_or_phenotypic_feature"
+        ],
+        "omnicorp_article_count": 9078
+      }
+    ],
+    "edges": [
+      {
+        "id": "1f6d1af9c9790d9e764acbcefa529560",
+        "source_id": "CHEBI:65173",
+        "target_id": "MONDO:0005090",
+        "type": "treats",
+        "ctime": 1584319702.9056776,
+        "predicate_id": "RO:0002606",
+        "relation": "RO:0002606",
+        "source_database": "mychem",
+        "publications": [],
+        "relation_label": "treats",
+        "edge_source": "mychem.get_adverse_events"
+      },
+      {
+        "id": "14403bd92938ce4daec86a4771bf62e5",
+        "source_id": "CHEBI:8707",
+        "target_id": "MONDO:0005090",
+        "type": "treats",
+        "ctime": 1584317841.9821916,
+        "predicate_id": "RO:0002606",
+        "relation": "RO:0002606",
+        "source_database": "mychem",
+        "publications": [],
+        "relation_label": "treats",
+        "edge_source": "mychem.get_adverse_events"
+      },
+      {
+        "id": "f07c7b7ecfe8842148bd274046d16b91",
+        "source_id": "CHEBI:3766",
+        "target_id": "MONDO:0005090",
+        "type": "treats",
+        "ctime": 1584319893.3806875,
+        "predicate_id": "RO:0002606",
+        "relation": "RO:0002606",
+        "source_database": "mychem",
+        "publications": [],
+        "relation_label": "treats",
+        "edge_source": "mychem.get_adverse_events"
+      },
+      {
+        "id": "b10e8f04da87590a3f4594b55cb5f622",
+        "source_id": "CHEBI:7735",
+        "target_id": "MONDO:0005090",
+        "type": "treats",
+        "ctime": 1584326904.0242105,
+        "predicate_id": "RO:0002606",
+        "relation": "RO:0002606",
+        "source_database": "mychem",
+        "publications": [],
+        "relation_label": "treats",
+        "edge_source": "mychem.get_adverse_events"
+      },
+      {
+        "id": "43821d8754c5fd847b24ae5bff93cf0b",
+        "source_id": "CHEBI:10119",
+        "target_id": "MONDO:0005090",
+        "type": "treats",
+        "ctime": 1584315972.6803536,
+        "predicate_id": "RO:0002606",
+        "relation": "RO:0002606",
+        "source_database": "mychem",
+        "publications": [],
+        "relation_label": "treats",
+        "edge_source": "mychem.get_adverse_events"
+      },
+      {
+        "id": "25ca4674bccf3d3623ec99ddd401fef8",
+        "source_id": "CHEBI:70735",
+        "target_id": "MONDO:0005090",
+        "type": "treats",
+        "ctime": 1584319958.1717777,
+        "predicate_id": "RO:0002606",
+        "relation": "RO:0002606",
+        "source_database": "mychem",
+        "publications": [],
+        "relation_label": "treats",
+        "edge_source": "mychem.get_adverse_events"
+      },
+      {
+        "id": "45bb9997c8ac47225836c8e74cf91b5a",
+        "source_id": "CHEBI:31236",
+        "target_id": "MONDO:0005090",
+        "type": "treats",
+        "ctime": 1584316094.4313107,
+        "predicate_id": "RO:0002606",
+        "relation": "RO:0002606",
+        "source_database": "mychem",
+        "publications": [],
+        "relation_label": "treats",
+        "edge_source": "mychem.get_adverse_events"
+      },
+      {
+        "id": "f35fb52da54f92f60696a99e84bfa51a",
+        "source_id": "CHEBI:8871",
+        "target_id": "MONDO:0005090",
+        "type": "treats",
+        "ctime": 1584318198.6242623,
+        "predicate_id": "RO:0002606",
+        "relation": "RO:0002606",
+        "source_database": "mychem",
+        "publications": [],
+        "relation_label": "treats",
+        "edge_source": "mychem.get_adverse_events"
+      },
+      {
+        "id": "5f9d7ec7475fcd03c7d0349c3d43ffd7",
+        "source_id": "CHEBI:5613",
+        "target_id": "MONDO:0005090",
+        "type": "treats",
+        "ctime": 1584317923.8584208,
+        "predicate_id": "RO:0002606",
+        "relation": "RO:0002606",
+        "source_database": "mychem",
+        "publications": [],
+        "relation_label": "treats",
+        "edge_source": "mychem.get_adverse_events"
+      },
+      {
+        "id": "498c4c27bfd963f51fa822ad7f5a43cc",
+        "source_id": "CHEBI:31981",
+        "target_id": "MONDO:0005090",
+        "type": "treats",
+        "ctime": 1583352731.442637,
+        "predicate_id": "RO:0002606",
+        "relation": "CTD:therapeutic",
+        "source_database": "ctd",
+        "publications": [
+          "PMID:1322069"
+        ],
+        "relation_label": "therapeutic",
+        "edge_source": "ctd.disease_to_chemical"
+      },
+      {
+        "id": "ead0c39f0b111e2554d42e09c6639da7",
+        "source_id": "MESH:D014282",
+        "target_id": "MONDO:0005090",
+        "type": "treats",
+        "ctime": 1583352731.4443378,
+        "predicate_id": "RO:0002606",
+        "relation": "CTD:therapeutic",
+        "source_database": "ctd",
+        "publications": [
+          "PMID:391328",
+          "PMID:709472"
+        ],
+        "relation_label": "therapeutic",
+        "edge_source": "ctd.disease_to_chemical"
+      },
+      {
+        "id": "3c624dc8707e7087d30b693d3c064e5a",
+        "source_id": "MESH:D000068882",
+        "target_id": "MONDO:0005090",
+        "type": "treats",
+        "ctime": 1583352731.442537,
+        "predicate_id": "RO:0002606",
+        "relation": "CTD:therapeutic",
+        "source_database": "ctd",
+        "publications": [
+          "PMID:17460786",
+          "PMID:19713555",
+          "PMID:19825908",
+          "PMID:19855366"
+        ],
+        "relation_label": "therapeutic",
+        "edge_source": "ctd.disease_to_chemical"
+      },
+      {
+        "id": "5c92c1173e1b6b916355bc842d5c39e4",
+        "source_id": "MESH:D011352",
+        "target_id": "MONDO:0005090",
+        "type": "treats",
+        "ctime": 1583352731.44343,
+        "predicate_id": "RO:0002606",
+        "relation": "CTD:therapeutic",
+        "source_database": "ctd",
+        "publications": [
+          "PMID:12095078",
+          "PMID:709472"
+        ],
+        "relation_label": "therapeutic",
+        "edge_source": "ctd.disease_to_chemical"
+      },
+      {
+        "id": "4c31cfcb4fcca8119bacadf5ff9c7c3f",
+        "source_id": "MESH:D013469",
+        "target_id": "MONDO:0005090",
+        "type": "treats",
+        "ctime": 1583352728.5877695,
+        "predicate_id": "RO:0002606",
+        "relation": "CTD:therapeutic",
+        "source_database": "ctd",
+        "publications": [
+          "PMID:6367362"
+        ],
+        "relation_label": "therapeutic",
+        "edge_source": "ctd.disease_to_chemical"
+      },
+      {
+        "id": "b59a6c9652482f7a0b9f83afc9ae4146",
+        "source_id": "MESH:D011433",
+        "target_id": "MONDO:0005090",
+        "type": "treats",
+        "ctime": 1583352731.4435315,
+        "predicate_id": "RO:0002606",
+        "relation": "CTD:therapeutic",
+        "source_database": "ctd",
+        "publications": [
+          "PMID:4441828"
+        ],
+        "relation_label": "therapeutic",
+        "edge_source": "ctd.disease_to_chemical"
+      },
+      {
+        "id": "b81fdf71694595916d701accb5b538ac",
+        "source_id": "MESH:D008972",
+        "target_id": "MONDO:0005090",
+        "type": "treats",
+        "ctime": 1583352731.4420745,
+        "predicate_id": "RO:0002606",
+        "relation": "CTD:therapeutic",
+        "source_database": "ctd",
+        "publications": [
+          "PMID:1971192",
+          "PMID:2081681",
+          "PMID:7446763"
+        ],
+        "relation_label": "therapeutic",
+        "edge_source": "ctd.disease_to_chemical"
+      },
+      {
+        "id": "48bfeb51ce3308d17910fcf7e55fe738",
+        "source_id": "CHEMBL.COMPOUND:CHEMBL218166",
+        "target_id": "MONDO:0005090",
+        "type": "treats",
+        "ctime": 1583352731.4393945,
+        "predicate_id": "RO:0002606",
+        "relation": "CTD:therapeutic",
+        "source_database": "ctd",
+        "publications": [
+          "PMID:21591752"
+        ],
+        "relation_label": "therapeutic",
+        "edge_source": "ctd.disease_to_chemical"
+      },
+      {
+        "id": "477e260e9fd1ccd91159dbe57337c22e",
+        "source_id": "MESH:C515050",
+        "target_id": "MONDO:0005090",
+        "type": "treats",
+        "ctime": 1583352731.444756,
+        "predicate_id": "RO:0002606",
+        "relation": "CTD:therapeutic",
+        "source_database": "ctd",
+        "publications": [
+          "PMID:12095078"
+        ],
+        "relation_label": "therapeutic",
+        "edge_source": "ctd.disease_to_chemical"
+      },
+      {
+        "id": "d30fdf6603478e158753fa54579c3bc8",
+        "source_id": "CHEBI:135778",
+        "target_id": "MONDO:0005090",
+        "type": "treats",
+        "ctime": 1583352731.4386916,
+        "predicate_id": "RO:0002606",
+        "relation": "CTD:therapeutic",
+        "source_database": "ctd",
+        "publications": [
+          "PMID:4076529"
+        ],
+        "relation_label": "therapeutic",
+        "edge_source": "ctd.disease_to_chemical"
+      },
+      {
+        "id": "a6dd784998583735c9cdcae7246c05f3",
+        "source_id": "MESH:C060342",
+        "target_id": "MONDO:0005090",
+        "type": "treats",
+        "ctime": 1583352731.4401083,
+        "predicate_id": "RO:0002606",
+        "relation": "CTD:therapeutic",
+        "source_database": "ctd",
+        "publications": [
+          "PMID:18464063"
+        ],
+        "relation_label": "therapeutic",
+        "edge_source": "ctd.disease_to_chemical"
+      },
+      {
+        "id": "ecd1e07e353f9416c93c3e9b5e098d77",
+        "source_id": "MESH:D012906",
+        "target_id": "MONDO:0005090",
+        "type": "treats",
+        "ctime": 1583352731.443968,
+        "predicate_id": "RO:0002606",
+        "relation": "CTD:therapeutic",
+        "source_database": "ctd",
+        "publications": [
+          "PMID:8958597"
+        ],
+        "relation_label": "therapeutic",
+        "edge_source": "ctd.disease_to_chemical"
+      },
+      {
+        "id": "e68666fd412ddb3addad4edb94d9e788",
+        "source_id": "MESH:D000077408",
+        "target_id": "MONDO:0005090",
+        "type": "treats",
+        "ctime": 1583352731.4420311,
+        "predicate_id": "RO:0002606",
+        "relation": "CTD:therapeutic",
+        "source_database": "ctd",
+        "publications": [
+          "PMID:21064019"
+        ],
+        "relation_label": "therapeutic",
+        "edge_source": "ctd.disease_to_chemical"
+      },
+      {
+        "id": "faf12afc64a27e030125dd3011fcff06",
+        "source_id": "MESH:C007761",
+        "target_id": "MONDO:0005090",
+        "type": "treats",
+        "ctime": 1583352731.4408097,
+        "predicate_id": "RO:0002606",
+        "relation": "CTD:therapeutic",
+        "source_database": "ctd",
+        "publications": [
+          "PMID:18464063",
+          "PMID:990663"
+        ],
+        "relation_label": "therapeutic",
+        "edge_source": "ctd.disease_to_chemical"
+      },
+      {
+        "id": "46d04f20397875b7376435c704c3bd02",
+        "source_id": "MESH:D012436",
+        "target_id": "MONDO:0005090",
+        "type": "treats",
+        "ctime": 1583352731.4438016,
+        "predicate_id": "RO:0002606",
+        "relation": "CTD:therapeutic",
+        "source_database": "ctd",
+        "publications": [
+          "PMID:18824331"
+        ],
+        "relation_label": "therapeutic",
+        "edge_source": "ctd.disease_to_chemical"
+      },
+      {
+        "id": "4dcb2c732371e398b09ec26055f6359b",
+        "source_id": "CHEMBL.COMPOUND:CHEMBL2105481",
+        "target_id": "MONDO:0005090",
+        "type": "treats",
+        "ctime": 1583352731.4446611,
+        "predicate_id": "RO:0002606",
+        "relation": "CTD:therapeutic",
+        "source_database": "ctd",
+        "publications": [
+          "PMID:6148118"
+        ],
+        "relation_label": "therapeutic",
+        "edge_source": "ctd.disease_to_chemical"
+      },
+      {
+        "id": "9b613f3b2cf64f7a0b7ca99f716d67d6",
+        "source_id": "MESH:D000077582",
+        "target_id": "MONDO:0005090",
+        "type": "treats",
+        "ctime": 1583352731.4388447,
+        "predicate_id": "RO:0002606",
+        "relation": "CTD:therapeutic",
+        "source_database": "ctd",
+        "publications": [
+          "PMID:10221135",
+          "PMID:11829208",
+          "PMID:12893676",
+          "PMID:14966260",
+          "PMID:16225977",
+          "PMID:16942633",
+          "PMID:16963229",
+          "PMID:18308817",
+          "PMID:18504810",
+          "PMID:18774435",
+          "PMID:19673087",
+          "PMID:20050717",
+          "PMID:25085534",
+          "PMID:6147865",
+          "PMID:8996184"
+        ],
+        "relation_label": "therapeutic",
+        "edge_source": "ctd.disease_to_chemical"
+      },
+      {
+        "id": "3f2dce542d551845ef737b2104a0a382",
+        "source_id": "CHEBI:64050",
+        "target_id": "MONDO:0005090",
+        "type": "treats",
+        "ctime": 1583352731.44228,
+        "predicate_id": "RO:0002606",
+        "relation": "CTD:therapeutic",
+        "source_database": "ctd",
+        "publications": [
+          "PMID:11151749"
+        ],
+        "relation_label": "therapeutic",
+        "edge_source": "ctd.disease_to_chemical"
+      },
+      {
+        "id": "d614c7ce9753c9c96776b0b8c0496b90",
+        "source_id": "MESH:D005473",
+        "target_id": "MONDO:0005090",
+        "type": "treats",
+        "ctime": 1583352731.4407206,
+        "predicate_id": "RO:0002606",
+        "relation": "CTD:therapeutic",
+        "source_database": "ctd",
+        "publications": [
+          "PMID:11910263"
+        ],
+        "relation_label": "therapeutic",
+        "edge_source": "ctd.disease_to_chemical"
+      },
+      {
+        "id": "4e71ece190e47455f7ae8b31d80dd3a9",
+        "source_id": "CHEMBL.COMPOUND:CHEMBL2106135",
+        "target_id": "MONDO:0005090",
+        "type": "treats",
+        "ctime": 1583352731.4396412,
+        "predicate_id": "RO:0002606",
+        "relation": "CTD:therapeutic",
+        "source_database": "ctd",
+        "publications": [
+          "PMID:1487623"
+        ],
+        "relation_label": "therapeutic",
+        "edge_source": "ctd.disease_to_chemical"
+      },
+      {
+        "id": "8efc24e375e9f21c0dcabd50d9df36e2",
+        "source_id": "MESH:D008653",
+        "target_id": "MONDO:0005090",
+        "type": "treats",
+        "ctime": 1583352731.4416714,
+        "predicate_id": "RO:0002606",
+        "relation": "CTD:therapeutic",
+        "source_database": "ctd",
+        "publications": [
+          "PMID:15285957"
+        ],
+        "relation_label": "therapeutic",
+        "edge_source": "ctd.disease_to_chemical"
+      },
+      {
+        "id": "444737174a86b6215191c9ac6115486b",
+        "source_id": "MESH:D011398",
+        "target_id": "MONDO:0005090",
+        "type": "treats",
+        "ctime": 1583352731.4434807,
+        "predicate_id": "RO:0002606",
+        "relation": "CTD:therapeutic",
+        "source_database": "ctd",
+        "publications": [
+          "PMID:1485575"
+        ],
+        "relation_label": "therapeutic",
+        "edge_source": "ctd.disease_to_chemical"
+      },
+      {
+        "id": "4a11a33f29fdbe47355079b7f43d97d0",
+        "source_id": "MESH:D008140",
+        "target_id": "MONDO:0005090",
+        "type": "treats",
+        "ctime": 1583352731.4415724,
+        "predicate_id": "RO:0002606",
+        "relation": "CTD:therapeutic",
+        "source_database": "ctd",
+        "publications": [
+          "PMID:12095078",
+          "PMID:9754850"
+        ],
+        "relation_label": "therapeutic",
+        "edge_source": "ctd.disease_to_chemical"
+      },
+      {
+        "id": "27e2d9c80f455b07035189d2d2185cc7",
+        "source_id": "MESH:C100234",
+        "target_id": "MONDO:0005090",
+        "type": "treats",
+        "ctime": 1583352731.4393065,
+        "predicate_id": "RO:0002606",
+        "relation": "CTD:therapeutic",
+        "source_database": "ctd",
+        "publications": [
+          "PMID:5336562"
+        ],
+        "relation_label": "therapeutic",
+        "edge_source": "ctd.disease_to_chemical"
+      },
+      {
+        "id": "d14eb3961c1f7388e1d825087793b09c",
+        "source_id": "MESH:D013881",
+        "target_id": "MONDO:0005090",
+        "type": "treats",
+        "ctime": 1583352731.4441214,
+        "predicate_id": "RO:0002606",
+        "relation": "CTD:therapeutic",
+        "source_database": "ctd",
+        "publications": [
+          "PMID:15285957",
+          "PMID:18634530",
+          "PMID:2773973",
+          "PMID:4065553",
+          "PMID:5237376",
+          "PMID:6123407",
+          "PMID:707646",
+          "PMID:709472",
+          "PMID:7435691",
+          "PMID:7446763"
+        ],
+        "relation_label": "therapeutic",
+        "edge_source": "ctd.disease_to_chemical"
+      },
+      {
+        "id": "926bbe3b8fa81d53f421602d766bccde",
+        "source_id": "MESH:C030265",
+        "target_id": "MONDO:0005090",
+        "type": "treats",
+        "ctime": 1583352731.442209,
+        "predicate_id": "RO:0002606",
+        "relation": "CTD:therapeutic",
+        "source_database": "ctd",
+        "publications": [
+          "PMID:11505224"
+        ],
+        "relation_label": "therapeutic",
+        "edge_source": "ctd.disease_to_chemical"
+      },
+      {
+        "id": "7e2638ffd0752352debdae9307986f8d",
+        "source_id": "MESH:D001712",
+        "target_id": "MONDO:0005090",
+        "type": "treats",
+        "ctime": 1583352731.4394462,
+        "predicate_id": "RO:0002606",
+        "relation": "CTD:therapeutic",
+        "source_database": "ctd",
+        "publications": [
+          "PMID:1322069"
+        ],
+        "relation_label": "therapeutic",
+        "edge_source": "ctd.disease_to_chemical"
+      },
+      {
+        "id": "0f708fa3e227b1fc99acf54b86ab0067",
+        "source_id": "MESH:D000069470",
+        "target_id": "MONDO:0005090",
+        "type": "treats",
+        "ctime": 1583352731.444431,
+        "predicate_id": "RO:0002606",
+        "relation": "CTD:therapeutic",
+        "source_database": "ctd",
+        "publications": [
+          "PMID:12380707"
+        ],
+        "relation_label": "therapeutic",
+        "edge_source": "ctd.disease_to_chemical"
+      },
+      {
+        "id": "ec69907b8aa355c68a3028d491774cb8",
+        "source_id": "CHEBI:92293",
+        "target_id": "MONDO:0005090",
+        "type": "treats",
+        "ctime": 1583352731.4431884,
+        "predicate_id": "RO:0002606",
+        "relation": "CTD:therapeutic",
+        "source_database": "ctd",
+        "publications": [
+          "PMID:1119614"
+        ],
+        "relation_label": "therapeutic",
+        "edge_source": "ctd.disease_to_chemical"
+      },
+      {
+        "id": "29805b4c97964fbcbc034e51592e1025",
+        "source_id": "MESH:C522667",
+        "target_id": "MONDO:0005090",
+        "type": "treats",
+        "ctime": 1583352731.4391065,
+        "predicate_id": "RO:0002606",
+        "relation": "CTD:therapeutic",
+        "source_database": "ctd",
+        "publications": [
+          "PMID:20520283"
+        ],
+        "relation_label": "therapeutic",
+        "edge_source": "ctd.disease_to_chemical"
+      },
+      {
+        "id": "62769563de9abea21d061f71c8e1f092",
+        "source_id": "CHEBI:34605",
+        "target_id": "MONDO:0005090",
+        "type": "treats",
+        "ctime": 1583352731.4384906,
+        "predicate_id": "RO:0002606",
+        "relation": "CTD:therapeutic",
+        "source_database": "ctd",
+        "publications": [
+          "PMID:16782180"
+        ],
+        "relation_label": "therapeutic",
+        "edge_source": "ctd.disease_to_chemical"
+      },
+      {
+        "id": "b350a7cdeb917e5427a848255024e654",
+        "source_id": "MESH:D003990",
+        "target_id": "MONDO:0005090",
+        "type": "treats",
+        "ctime": 1583352731.4404716,
+        "predicate_id": "RO:0002606",
+        "relation": "CTD:therapeutic",
+        "source_database": "ctd",
+        "publications": [
+          "PMID:5237376"
+        ],
+        "relation_label": "therapeutic",
+        "edge_source": "ctd.disease_to_chemical"
+      },
+      {
+        "id": "6878025413863037439",
+        "source_id": "CHEBI:8707",
+        "target_id": "MONDO:0004985",
+        "type": "treats"
+      },
+      {
+        "id": "-7950429506698507531",
+        "source_id": "MESH:D014282",
+        "target_id": "MONDO:0004985",
+        "type": "treats"
+      },
+      {
+        "id": "4154493370753010689",
+        "source_id": "CHEBI:7735",
+        "target_id": "MONDO:0004985",
+        "type": "treats"
+      },
+      {
+        "id": "-4349798301881810185",
+        "source_id": "CHEBI:5613",
+        "target_id": "MONDO:0004985",
+        "type": "treats"
+      },
+      {
+        "id": "6008916285095953533",
+        "source_id": "CHEBI:31236",
+        "target_id": "MONDO:0004985",
+        "type": "treats"
+      },
+      {
+        "id": "5896744110281421124",
+        "source_id": "MESH:D001712",
+        "target_id": "MONDO:0004985",
+        "type": "treats"
+      },
+      {
+        "id": "-4732781122994517410",
+        "source_id": "CHEBI:10119",
+        "target_id": "MONDO:0004985",
+        "type": "treats"
+      },
+      {
+        "id": "-7507305372605831862",
+        "source_id": "MESH:D011398",
+        "target_id": "MONDO:0004985",
+        "type": "treats"
+      },
+      {
+        "id": "-5513087202338337169",
+        "source_id": "MESH:D008653",
+        "target_id": "MONDO:0004985",
+        "type": "treats"
+      },
+      {
+        "id": "-6103542527948243491",
+        "source_id": "MESH:D013469",
+        "target_id": "MONDO:0004985",
+        "type": "treats"
+      },
+      {
+        "id": "8105171369240467018",
+        "source_id": "MESH:D005473",
+        "target_id": "MONDO:0004985",
+        "type": "treats"
+      },
+      {
+        "id": "6112799945122878599",
+        "source_id": "CHEBI:3766",
+        "target_id": "MONDO:0004985",
+        "type": "treats"
+      },
+      {
+        "id": "5038839236277679657",
+        "source_id": "MESH:D013881",
+        "target_id": "MONDO:0004985",
+        "type": "treats"
+      },
+      {
+        "id": "-7711103270866585879",
+        "source_id": "CHEBI:70735",
+        "target_id": "MONDO:0004985",
+        "type": "treats"
+      },
+      {
+        "id": "8655502730642576852",
+        "source_id": "MESH:D011352",
+        "target_id": "MONDO:0004985",
+        "type": "treats"
+      },
+      {
+        "id": "-375984081016907419",
+        "source_id": "CHEBI:8871",
+        "target_id": "MONDO:0004985",
+        "type": "treats"
+      },
+      {
+        "id": "-3602937035054302897",
+        "source_id": "CHEBI:8707",
+        "target_id": "MONDO:0011552",
+        "type": "treats"
+      },
+      {
+        "id": "-2036566501268119119",
+        "source_id": "CHEBI:7735",
+        "target_id": "MONDO:0011552",
+        "type": "treats"
+      },
+      {
+        "id": "-5689304263517049529",
+        "source_id": "CHEBI:5613",
+        "target_id": "MONDO:0011552",
+        "type": "treats"
+      },
+      {
+        "id": "-4281548860317661491",
+        "source_id": "CHEBI:31236",
+        "target_id": "MONDO:0011552",
+        "type": "treats"
+      },
+      {
+        "id": "2672134749508767710",
+        "source_id": "CHEBI:65173",
+        "target_id": "MONDO:0011552",
+        "type": "treats"
+      },
+      {
+        "id": "-7514071192782330151",
+        "source_id": "MESH:D013881",
+        "target_id": "MONDO:0011552",
+        "type": "treats"
+      },
+      {
+        "id": "-5382694374086368082",
+        "source_id": "CHEBI:10119",
+        "target_id": "MONDO:0011552",
+        "type": "treats"
+      },
+      {
+        "id": "-3430614955284991846",
+        "source_id": "MESH:D005473",
+        "target_id": "MONDO:0011552",
+        "type": "treats"
+      },
+      {
+        "id": "8721791765556081975",
+        "source_id": "CHEBI:3766",
+        "target_id": "MONDO:0011552",
+        "type": "treats"
+      },
+      {
+        "id": "-2821951771878666050",
+        "source_id": "MESH:D008140",
+        "target_id": "MONDO:0011552",
+        "type": "treats"
+      },
+      {
+        "id": "-7407705456216866919",
+        "source_id": "CHEBI:70735",
+        "target_id": "MONDO:0011552",
+        "type": "treats"
+      },
+      {
+        "id": "-3692334211239932235",
+        "source_id": "CHEBI:8871",
+        "target_id": "MONDO:0011552",
+        "type": "treats"
+      },
+      {
+        "id": "9191689101766575094",
+        "source_id": "MESH:D000069470",
+        "target_id": "MONDO:0019790",
+        "type": "contributes_to"
+      },
+      {
+        "id": "-9005582744011621404",
+        "source_id": "CHEBI:5613",
+        "target_id": "MONDO:0019790",
+        "type": "contributes_to"
+      },
+      {
+        "id": "6523513369983346474",
+        "source_id": "CHEBI:31236",
+        "target_id": "MONDO:0019790",
+        "type": "contributes_to"
+      },
+      {
+        "id": "6490798625887314518",
+        "source_id": "MESH:D013881",
+        "target_id": "MONDO:0019790",
+        "type": "contributes_to"
+      },
+      {
+        "id": "672300843764922289",
+        "source_id": "CHEBI:10119",
+        "target_id": "MONDO:0019790",
+        "type": "contributes_to"
+      },
+      {
+        "id": "7708493085475630173",
+        "source_id": "MESH:D011398",
+        "target_id": "MONDO:0019790",
+        "type": "contributes_to"
+      },
+      {
+        "id": "4325772177267623447",
+        "source_id": "MESH:D000077582",
+        "target_id": "MONDO:0019790",
+        "type": "contributes_to"
+      },
+      {
+        "id": "-2600856695005313164",
+        "source_id": "MESH:D008972",
+        "target_id": "MONDO:0019790",
+        "type": "contributes_to"
+      },
+      {
+        "id": "8739461348402766836",
+        "source_id": "CHEBI:3766",
+        "target_id": "MONDO:0019790",
+        "type": "contributes_to"
+      },
+      {
+        "id": "-884870587413398727",
+        "source_id": "MESH:C007761",
+        "target_id": "MONDO:0019790",
+        "type": "contributes_to"
+      },
+      {
+        "id": "6686572420378851751",
+        "source_id": "MESH:D011352",
+        "target_id": "MONDO:0019790",
+        "type": "contributes_to"
+      },
+      {
+        "id": "8000298095778413586",
+        "source_id": "CHEBI:8871",
+        "target_id": "MONDO:0019790",
+        "type": "contributes_to"
+      },
+      {
+        "id": "-1061304296024582542",
+        "source_id": "CHEBI:7735",
+        "target_id": "MONDO:0005804",
+        "type": "contributes_to"
+      },
+      {
+        "id": "-5625489836607458262",
+        "source_id": "MESH:D000069470",
+        "target_id": "MONDO:0005804",
+        "type": "contributes_to"
+      },
+      {
+        "id": "-4531208579869110648",
+        "source_id": "CHEBI:5613",
+        "target_id": "MONDO:0005804",
+        "type": "contributes_to"
+      },
+      {
+        "id": "-5870362081136959670",
+        "source_id": "MESH:D013881",
+        "target_id": "MONDO:0005804",
+        "type": "contributes_to"
+      },
+      {
+        "id": "113269640907308629",
+        "source_id": "CHEBI:10119",
+        "target_id": "MONDO:0005804",
+        "type": "contributes_to"
+      },
+      {
+        "id": "-5214831124842227754",
+        "source_id": "MESH:D013469",
+        "target_id": "MONDO:0005804",
+        "type": "contributes_to"
+      },
+      {
+        "id": "3957404463100624681",
+        "source_id": "MESH:D005473",
+        "target_id": "MONDO:0005804",
+        "type": "contributes_to"
+      },
+      {
+        "id": "-1310006511909716744",
+        "source_id": "CHEBI:3766",
+        "target_id": "MONDO:0005804",
+        "type": "contributes_to"
+      },
+      {
+        "id": "-3576357953206954376",
+        "source_id": "MESH:D008972",
+        "target_id": "MONDO:0005804",
+        "type": "contributes_to"
+      },
+      {
+        "id": "277579601087748283",
+        "source_id": "MESH:D000077582",
+        "target_id": "MONDO:0005804",
+        "type": "contributes_to"
+      },
+      {
+        "id": "1902255578605881614",
+        "source_id": "CHEBI:8871",
+        "target_id": "MONDO:0005804",
+        "type": "contributes_to"
+      },
+      {
+        "id": "7249108970589608202",
+        "source_id": "CHEBI:7735",
+        "target_id": "MONDO:0006731",
+        "type": "contributes_to"
+      },
+      {
+        "id": "-5198590934450462318",
+        "source_id": "MESH:D000069470",
+        "target_id": "MONDO:0006731",
+        "type": "contributes_to"
+      },
+      {
+        "id": "4800661422038868768",
+        "source_id": "CHEBI:5613",
+        "target_id": "MONDO:0006731",
+        "type": "contributes_to"
+      },
+      {
+        "id": "778781801369598350",
+        "source_id": "CHEBI:31236",
+        "target_id": "MONDO:0006731",
+        "type": "contributes_to"
+      },
+      {
+        "id": "-4011029275528409363",
+        "source_id": "CHEBI:10119",
+        "target_id": "MONDO:0006731",
+        "type": "contributes_to"
+      },
+      {
+        "id": "6019138631983979384",
+        "source_id": "MESH:D008653",
+        "target_id": "MONDO:0006731",
+        "type": "contributes_to"
+      },
+      {
+        "id": "409316489987944385",
+        "source_id": "MESH:D005473",
+        "target_id": "MONDO:0006731",
+        "type": "contributes_to"
+      },
+      {
+        "id": "3228142757943468432",
+        "source_id": "CHEBI:3766",
+        "target_id": "MONDO:0006731",
+        "type": "contributes_to"
+      },
+      {
+        "id": "-6601825417324012366",
+        "source_id": "MESH:D013881",
+        "target_id": "MONDO:0006731",
+        "type": "contributes_to"
+      },
+      {
+        "id": "5900986011888128473",
+        "source_id": "MESH:D003990",
+        "target_id": "MONDO:0006731",
+        "type": "contributes_to"
+      },
+      {
+        "id": "7946187969751317843",
+        "source_id": "MESH:D000077582",
+        "target_id": "MONDO:0006731",
+        "type": "contributes_to"
+      },
+      {
+        "id": "-6972979114562138506",
+        "source_id": "CHEBI:8871",
+        "target_id": "MONDO:0006731",
+        "type": "contributes_to"
+      },
+      {
+        "id": "-8775666285376168509",
+        "source_id": "MESH:D011433",
+        "target_id": "MONDO:0005466",
+        "type": "contributes_to"
+      },
+      {
+        "id": "-1082558950480460648",
+        "source_id": "MESH:D000069470",
+        "target_id": "MONDO:0005466",
+        "type": "contributes_to"
+      },
+      {
+        "id": "8044659037332195408",
+        "source_id": "CHEBI:7735",
+        "target_id": "MONDO:0005466",
+        "type": "contributes_to"
+      },
+      {
+        "id": "-8029565172048478246",
+        "source_id": "CHEBI:5613",
+        "target_id": "MONDO:0005466",
+        "type": "contributes_to"
+      },
+      {
+        "id": "-563570001699188780",
+        "source_id": "CHEBI:31236",
+        "target_id": "MONDO:0005466",
+        "type": "contributes_to"
+      },
+      {
+        "id": "-4902033109589333640",
+        "source_id": "MESH:D013881",
+        "target_id": "MONDO:0005466",
+        "type": "contributes_to"
+      },
+      {
+        "id": "2469858430708297479",
+        "source_id": "MESH:D011398",
+        "target_id": "MONDO:0005466",
+        "type": "contributes_to"
+      },
+      {
+        "id": "-7684933401502972409",
+        "source_id": "MESH:D005473",
+        "target_id": "MONDO:0005466",
+        "type": "contributes_to"
+      },
+      {
+        "id": "-2018046158300641334",
+        "source_id": "CHEBI:3766",
+        "target_id": "MONDO:0005466",
+        "type": "contributes_to"
+      },
+      {
+        "id": "1932055102892904387",
+        "source_id": "MESH:D008140",
+        "target_id": "MONDO:0005466",
+        "type": "contributes_to"
+      },
+      {
+        "id": "-6949345259046099169",
+        "source_id": "MESH:D003990",
+        "target_id": "MONDO:0005466",
+        "type": "contributes_to"
+      },
+      {
+        "id": "-8110574637392439364",
+        "source_id": "CHEBI:8871",
+        "target_id": "MONDO:0005466",
+        "type": "contributes_to"
+      },
+      {
+        "id": "4888023147390638344",
+        "source_id": "MESH:C522667",
+        "target_id": "MONDO:0001220",
+        "type": "treats"
+      },
+      {
+        "id": "7808811803180987829",
+        "source_id": "MESH:D011433",
+        "target_id": "MONDO:0001220",
+        "type": "treats"
+      },
+      {
+        "id": "1284362363045701314",
+        "source_id": "CHEBI:7735",
+        "target_id": "MONDO:0001220",
+        "type": "treats"
+      },
+      {
+        "id": "-2721430935200047750",
+        "source_id": "MESH:D000069470",
+        "target_id": "MONDO:0001220",
+        "type": "treats"
+      },
+      {
+        "id": "5465134243090038950",
+        "source_id": "CHEBI:31236",
+        "target_id": "MONDO:0001220",
+        "type": "treats"
+      },
+      {
+        "id": "7511467792749227979",
+        "source_id": "MESH:D012436",
+        "target_id": "MONDO:0001220",
+        "type": "treats"
+      },
+      {
+        "id": "1821046102343364101",
+        "source_id": "CHEBI:10119",
+        "target_id": "MONDO:0001220",
+        "type": "treats"
+      },
+      {
+        "id": "-1174456227016712231",
+        "source_id": "MESH:D011398",
+        "target_id": "MONDO:0001220",
+        "type": "treats"
+      },
+      {
+        "id": "7342738987638233672",
+        "source_id": "CHEBI:3766",
+        "target_id": "MONDO:0001220",
+        "type": "treats"
+      },
+      {
+        "id": "4199326379324748488",
+        "source_id": "MESH:D008972",
+        "target_id": "MONDO:0001220",
+        "type": "treats"
+      },
+      {
+        "id": "4447928982518789070",
+        "source_id": "MESH:D014282",
+        "target_id": "MONDO:0001220",
+        "type": "treats"
+      },
+      {
+        "id": "7793177503146015851",
+        "source_id": "MESH:D000077582",
+        "target_id": "MONDO:0001220",
+        "type": "treats"
+      },
+      {
+        "id": "-3861606725632480322",
+        "source_id": "CHEBI:8871",
+        "target_id": "MONDO:0001220",
+        "type": "treats"
+      },
+      {
+        "id": "6955043225709352755",
+        "source_id": "MESH:D011433",
+        "target_id": "MONDO:0000947",
+        "type": "contributes_to"
+      },
+      {
+        "id": "-4239673443003562808",
+        "source_id": "MESH:D000069470",
+        "target_id": "MONDO:0000947",
+        "type": "contributes_to"
+      },
+      {
+        "id": "1491531456521308224",
+        "source_id": "CHEBI:7735",
+        "target_id": "MONDO:0000947",
+        "type": "contributes_to"
+      },
+      {
+        "id": "4067348011150782440",
+        "source_id": "MESH:D013881",
+        "target_id": "MONDO:0000947",
+        "type": "contributes_to"
+      },
+      {
+        "id": "2637751340779862147",
+        "source_id": "CHEBI:10119",
+        "target_id": "MONDO:0000947",
+        "type": "contributes_to"
+      },
+      {
+        "id": "4637926927286489604",
+        "source_id": "MESH:D013469",
+        "target_id": "MONDO:0000947",
+        "type": "contributes_to"
+      },
+      {
+        "id": "7558865895637465431",
+        "source_id": "MESH:D005473",
+        "target_id": "MONDO:0000947",
+        "type": "contributes_to"
+      },
+      {
+        "id": "-5759351193094264838",
+        "source_id": "CHEBI:3766",
+        "target_id": "MONDO:0000947",
+        "type": "contributes_to"
+      },
+      {
+        "id": "7572156259469666611",
+        "source_id": "MESH:D008140",
+        "target_id": "MONDO:0000947",
+        "type": "contributes_to"
+      },
+      {
+        "id": "-6161827907572271092",
+        "source_id": "CHEBI:8871",
+        "target_id": "MONDO:0000947",
+        "type": "contributes_to"
+      },
+      {
+        "id": "6281542558886975516",
+        "source_id": "MESH:D011433",
+        "target_id": "MONDO:0001821",
+        "type": "contributes_to"
+      },
+      {
+        "id": "7019854002873610823",
+        "source_id": "MESH:D000069470",
+        "target_id": "MONDO:0001821",
+        "type": "contributes_to"
+      },
+      {
+        "id": "6301238355639971215",
+        "source_id": "CHEBI:7735",
+        "target_id": "MONDO:0001821",
+        "type": "contributes_to"
+      },
+      {
+        "id": "-5019115961127510681",
+        "source_id": "MESH:D013881",
+        "target_id": "MONDO:0001821",
+        "type": "contributes_to"
+      },
+      {
+        "id": "3239195488415194732",
+        "source_id": "CHEBI:10119",
+        "target_id": "MONDO:0001821",
+        "type": "contributes_to"
+      },
+      {
+        "id": "2975809162555465963",
+        "source_id": "MESH:D013469",
+        "target_id": "MONDO:0001821",
+        "type": "contributes_to"
+      },
+      {
+        "id": "-312188439148924712",
+        "source_id": "MESH:D005473",
+        "target_id": "MONDO:0001821",
+        "type": "contributes_to"
+      },
+      {
+        "id": "8601234880450130505",
+        "source_id": "CHEBI:3766",
+        "target_id": "MONDO:0001821",
+        "type": "contributes_to"
+      },
+      {
+        "id": "-5348600792812983780",
+        "source_id": "MESH:D008140",
+        "target_id": "MONDO:0001821",
+        "type": "contributes_to"
+      },
+      {
+        "id": "-8847037924218056157",
+        "source_id": "CHEBI:8871",
+        "target_id": "MONDO:0001821",
+        "type": "contributes_to"
+      },
+      {
+        "id": "1731452357765047931",
+        "source_id": "MESH:C522667",
+        "target_id": "MONDO:0003996",
+        "type": "contributes_to"
+      },
+      {
+        "id": "-3924457529225514661",
+        "source_id": "CHEMBL.COMPOUND:CHEMBL2106135",
+        "target_id": "MONDO:0003996",
+        "type": "contributes_to"
+      },
+      {
+        "id": "7741414394506304949",
+        "source_id": "CHEBI:7735",
+        "target_id": "MONDO:0003996",
+        "type": "contributes_to"
+      },
+      {
+        "id": "5856721719705679373",
+        "source_id": "MESH:D013881",
+        "target_id": "MONDO:0003996",
+        "type": "contributes_to"
+      },
+      {
+        "id": "4871934331348264722",
+        "source_id": "CHEBI:10119",
+        "target_id": "MONDO:0003996",
+        "type": "contributes_to"
+      },
+      {
+        "id": "-3393133581320864775",
+        "source_id": "MESH:D013469",
+        "target_id": "MONDO:0003996",
+        "type": "contributes_to"
+      },
+      {
+        "id": "-2246407948511911578",
+        "source_id": "MESH:D005473",
+        "target_id": "MONDO:0003996",
+        "type": "contributes_to"
+      },
+      {
+        "id": "553658486186695099",
+        "source_id": "MESH:D008972",
+        "target_id": "MONDO:0003996",
+        "type": "contributes_to"
+      },
+      {
+        "id": "-7897425296690351813",
+        "source_id": "CHEBI:3766",
+        "target_id": "MONDO:0003996",
+        "type": "contributes_to"
+      },
+      {
+        "id": "5770792252551960458",
+        "source_id": "MESH:C007761",
+        "target_id": "MONDO:0003996",
+        "type": "contributes_to"
+      },
+      {
+        "id": "1539859625233732984",
+        "source_id": "MESH:D000077582",
+        "target_id": "MONDO:0003996",
+        "type": "contributes_to"
+      },
+      {
+        "id": "-5491944953753996282",
+        "source_id": "CHEBI:7735",
+        "target_id": "MONDO:0011728",
+        "type": "contributes_to"
+      },
+      {
+        "id": "2267343042018516606",
+        "source_id": "MESH:D000069470",
+        "target_id": "MONDO:0011728",
+        "type": "contributes_to"
+      },
+      {
+        "id": "848201929983221596",
+        "source_id": "CHEBI:5613",
+        "target_id": "MONDO:0011728",
+        "type": "contributes_to"
+      },
+      {
+        "id": "2727619992641654831",
+        "source_id": "MESH:D012436",
+        "target_id": "MONDO:0011728",
+        "type": "contributes_to"
+      },
+      {
+        "id": "7827471067704430377",
+        "source_id": "CHEBI:10119",
+        "target_id": "MONDO:0011728",
+        "type": "contributes_to"
+      },
+      {
+        "id": "-1378793720638841003",
+        "source_id": "MESH:D011398",
+        "target_id": "MONDO:0011728",
+        "type": "contributes_to"
+      },
+      {
+        "id": "4646137372359683669",
+        "source_id": "MESH:D005473",
+        "target_id": "MONDO:0011728",
+        "type": "contributes_to"
+      },
+      {
+        "id": "-4924404144949975220",
+        "source_id": "CHEBI:3766",
+        "target_id": "MONDO:0011728",
+        "type": "contributes_to"
+      },
+      {
+        "id": "6522994772687627102",
+        "source_id": "MESH:D013881",
+        "target_id": "MONDO:0011728",
+        "type": "contributes_to"
+      },
+      {
+        "id": "-5787985267163603999",
+        "source_id": "MESH:C007761",
+        "target_id": "MONDO:0011728",
+        "type": "contributes_to"
+      },
+      {
+        "id": "6892156447309160349",
+        "source_id": "MESH:D003990",
+        "target_id": "MONDO:0011728",
+        "type": "contributes_to"
+      },
+      {
+        "id": "-10230626008975302",
+        "source_id": "CHEBI:8871",
+        "target_id": "MONDO:0011728",
+        "type": "contributes_to"
+      },
+      {
+        "id": "8154983881750916768",
+        "source_id": "CHEBI:7735",
+        "target_id": "HP:0005986",
+        "type": "contributes_to"
+      },
+      {
+        "id": "-5458939759379515416",
+        "source_id": "MESH:D000069470",
+        "target_id": "HP:0005986",
+        "type": "contributes_to"
+      },
+      {
+        "id": "8068497052082100618",
+        "source_id": "CHEBI:5613",
+        "target_id": "HP:0005986",
+        "type": "contributes_to"
+      },
+      {
+        "id": "-5314436861094858659",
+        "source_id": "MESH:D012436",
+        "target_id": "HP:0005986",
+        "type": "contributes_to"
+      },
+      {
+        "id": "7637025660016775715",
+        "source_id": "CHEBI:10119",
+        "target_id": "HP:0005986",
+        "type": "contributes_to"
+      },
+      {
+        "id": "1605542730135855531",
+        "source_id": "MESH:C007761",
+        "target_id": "HP:0005986",
+        "type": "contributes_to"
+      },
+      {
+        "id": "-1074031873393960166",
+        "source_id": "CHEBI:3766",
+        "target_id": "HP:0005986",
+        "type": "contributes_to"
+      },
+      {
+        "id": "-2027718343702037304",
+        "source_id": "MESH:D013881",
+        "target_id": "HP:0005986",
+        "type": "contributes_to"
+      },
+      {
+        "id": "9109175573202151279",
+        "source_id": "MESH:D003990",
+        "target_id": "HP:0005986",
+        "type": "contributes_to"
+      },
+      {
+        "id": "-3870493768894112148",
+        "source_id": "CHEBI:8871",
+        "target_id": "HP:0005986",
+        "type": "contributes_to"
+      },
+      {
+        "id": "-6632089769227922151",
+        "source_id": "CHEBI:8707",
+        "target_id": "MONDO:0010096",
+        "type": "contraindicated_for"
+      },
+      {
+        "id": "-3228930265803780121",
+        "source_id": "CHEBI:7735",
+        "target_id": "MONDO:0010096",
+        "type": "contraindicated_for"
+      },
+      {
+        "id": "-2846440941249737967",
+        "source_id": "CHEBI:5613",
+        "target_id": "MONDO:0010096",
+        "type": "contraindicated_for"
+      },
+      {
+        "id": "2548681795836610915",
+        "source_id": "CHEBI:31236",
+        "target_id": "MONDO:0010096",
+        "type": "contraindicated_for"
+      },
+      {
+        "id": "3087435688090461204",
+        "source_id": "CHEBI:65173",
+        "target_id": "MONDO:0010096",
+        "type": "contraindicated_for"
+      },
+      {
+        "id": "4502297031710166852",
+        "source_id": "CHEBI:10119",
+        "target_id": "MONDO:0010096",
+        "type": "contraindicated_for"
+      },
+      {
+        "id": "-7517994081457988447",
+        "source_id": "CHEBI:3766",
+        "target_id": "MONDO:0010096",
+        "type": "contraindicated_for"
+      },
+      {
+        "id": "3313394613794454479",
+        "source_id": "CHEBI:70735",
+        "target_id": "MONDO:0010096",
+        "type": "contraindicated_for"
+      },
+      {
+        "id": "-5376353285230522037",
+        "source_id": "CHEBI:8871",
+        "target_id": "MONDO:0010096",
+        "type": "contraindicated_for"
+      },
+      {
+        "id": "-6672409449485326295",
+        "source_id": "CHEBI:7735",
+        "target_id": "MONDO:0002442",
+        "type": "contributes_to"
+      },
+      {
+        "id": "-6827050753397046369",
+        "source_id": "CHEBI:5613",
+        "target_id": "MONDO:0002442",
+        "type": "contributes_to"
+      },
+      {
+        "id": "6861170717065171877",
+        "source_id": "CHEBI:31236",
+        "target_id": "MONDO:0002442",
+        "type": "contributes_to"
+      },
+      {
+        "id": "-5574806182870017535",
+        "source_id": "MESH:D013881",
+        "target_id": "MONDO:0002442",
+        "type": "contributes_to"
+      },
+      {
+        "id": "7080295629003475718",
+        "source_id": "CHEBI:10119",
+        "target_id": "MONDO:0002442",
+        "type": "contributes_to"
+      },
+      {
+        "id": "2767569132135140807",
+        "source_id": "MESH:D008653",
+        "target_id": "MONDO:0002442",
+        "type": "contributes_to"
+      },
+      {
+        "id": "-753426095348810382",
+        "source_id": "MESH:D005473",
+        "target_id": "MONDO:0002442",
+        "type": "contributes_to"
+      },
+      {
+        "id": "-3677426254751171665",
+        "source_id": "CHEBI:3766",
+        "target_id": "MONDO:0002442",
+        "type": "contributes_to"
+      },
+      {
+        "id": "6589477666846826678",
+        "source_id": "MESH:D008140",
+        "target_id": "MONDO:0002442",
+        "type": "contributes_to"
+      },
+      {
+        "id": "-1587247218753308308",
+        "source_id": "MESH:D000077582",
+        "target_id": "MONDO:0002442",
+        "type": "contributes_to"
+      },
+      {
+        "id": "7405594811679801021",
+        "source_id": "CHEBI:8871",
+        "target_id": "MONDO:0002442",
+        "type": "contributes_to"
+      },
+      {
+        "id": "185545632135368478",
+        "source_id": "CHEBI:8707",
+        "target_id": "NCBIGene:3005",
+        "type": "decreases_activity_of"
+      },
+      {
+        "id": "6598173366866798268",
+        "source_id": "CHEBI:7735",
+        "target_id": "NCBIGene:3005",
+        "type": "decreases_activity_of"
+      },
+      {
+        "id": "6904698504564010150",
+        "source_id": "CHEBI:5613",
+        "target_id": "NCBIGene:3005",
+        "type": "decreases_activity_of"
+      },
+      {
+        "id": "2903477335087171128",
+        "source_id": "CHEBI:31236",
+        "target_id": "NCBIGene:3005",
+        "type": "decreases_activity_of"
+      },
+      {
+        "id": "-2591066488505739969",
+        "source_id": "CHEBI:10119",
+        "target_id": "NCBIGene:3005",
+        "type": "decreases_activity_of"
+      },
+      {
+        "id": "-4419708991396102602",
+        "source_id": "CHEBI:3766",
+        "target_id": "NCBIGene:3005",
+        "type": "decreases_activity_of"
+      },
+      {
+        "id": "4999754743720440144",
+        "source_id": "CHEBI:8871",
+        "target_id": "NCBIGene:3005",
+        "type": "decreases_activity_of"
+      },
+      {
+        "id": "3561452259725721186",
+        "source_id": "CHEBI:8707",
+        "target_id": "MONDO:0004745",
+        "type": "causes_adverse_event"
+      },
+      {
+        "id": "-4648464691848319088",
+        "source_id": "CHEBI:7735",
+        "target_id": "MONDO:0004745",
+        "type": "causes_adverse_event"
+      },
+      {
+        "id": "-8156495696967329638",
+        "source_id": "CHEBI:5613",
+        "target_id": "MONDO:0004745",
+        "type": "causes_adverse_event"
+      },
+      {
+        "id": "-8823903150151534828",
+        "source_id": "CHEBI:31236",
+        "target_id": "MONDO:0004745",
+        "type": "causes_adverse_event"
+      },
+      {
+        "id": "-1962044768136291229",
+        "source_id": "CHEBI:65173",
+        "target_id": "MONDO:0004745",
+        "type": "causes_adverse_event"
+      },
+      {
+        "id": "-5659376266817130189",
+        "source_id": "CHEBI:10119",
+        "target_id": "MONDO:0004745",
+        "type": "causes_adverse_event"
+      },
+      {
+        "id": "-3284564226623813878",
+        "source_id": "CHEBI:3766",
+        "target_id": "MONDO:0004745",
+        "type": "causes_adverse_event"
+      },
+      {
+        "id": "-1005251232936558216",
+        "source_id": "CHEBI:70735",
+        "target_id": "MONDO:0004745",
+        "type": "causes_adverse_event"
+      },
+      {
+        "id": "-4872118121976529156",
+        "source_id": "CHEBI:8871",
+        "target_id": "MONDO:0004745",
+        "type": "causes_adverse_event"
+      },
+      {
+        "id": "6553784974715878521",
+        "source_id": "MESH:D011433",
+        "target_id": "MONDO:0001442",
+        "type": "contributes_to"
+      },
+      {
+        "id": "-4779071809644295298",
+        "source_id": "MESH:D000069470",
+        "target_id": "MONDO:0001442",
+        "type": "contributes_to"
+      },
+      {
+        "id": "-1588948501470902522",
+        "source_id": "CHEBI:7735",
+        "target_id": "MONDO:0001442",
+        "type": "contributes_to"
+      },
+      {
+        "id": "-7716233646038627236",
+        "source_id": "CHEBI:5613",
+        "target_id": "MONDO:0001442",
+        "type": "contributes_to"
+      },
+      {
+        "id": "-8525235098658116318",
+        "source_id": "CHEBI:31236",
+        "target_id": "MONDO:0001442",
+        "type": "contributes_to"
+      },
+      {
+        "id": "1097019692333158494",
+        "source_id": "MESH:D013881",
+        "target_id": "MONDO:0001442",
+        "type": "contributes_to"
+      },
+      {
+        "id": "5460400504505329543",
+        "source_id": "MESH:C515050",
+        "target_id": "MONDO:0001442",
+        "type": "contributes_to"
+      },
+      {
+        "id": "4344434931242275518",
+        "source_id": "MESH:D012906",
+        "target_id": "MONDO:0001442",
+        "type": "contributes_to"
+      },
+      {
+        "id": "4052060478951709525",
+        "source_id": "MESH:D005473",
+        "target_id": "MONDO:0001442",
+        "type": "contributes_to"
+      },
+      {
+        "id": "3111485969520759884",
+        "source_id": "CHEBI:3766",
+        "target_id": "MONDO:0001442",
+        "type": "contributes_to"
+      },
+      {
+        "id": "-7048218732797866375",
+        "source_id": "MESH:D008140",
+        "target_id": "MONDO:0001442",
+        "type": "contributes_to"
+      },
+      {
+        "id": "5690703065649472826",
+        "source_id": "CHEBI:8871",
+        "target_id": "MONDO:0001442",
+        "type": "contributes_to"
+      },
+      {
+        "id": "6336138413476724206",
+        "source_id": "CHEBI:8707",
+        "target_id": "MONDO:0019790",
+        "type": "contraindicated_for"
+      },
+      {
+        "id": "-5968710425447150612",
+        "source_id": "CHEBI:7735",
+        "target_id": "MONDO:0019790",
+        "type": "contraindicated_for"
+      },
+      {
+        "id": "2542756441822673782",
+        "source_id": "CHEBI:5613",
+        "target_id": "MONDO:0019790",
+        "type": "contraindicated_for"
+      },
+      {
+        "id": "3932779916271202568",
+        "source_id": "CHEBI:31236",
+        "target_id": "MONDO:0019790",
+        "type": "contraindicated_for"
+      },
+      {
+        "id": "3423002498120100671",
+        "source_id": "CHEBI:65173",
+        "target_id": "MONDO:0019790",
+        "type": "contraindicated_for"
+      },
+      {
+        "id": "-5202001598824284145",
+        "source_id": "CHEBI:10119",
+        "target_id": "MONDO:0019790",
+        "type": "contraindicated_for"
+      },
+      {
+        "id": "-2172570163715538074",
+        "source_id": "CHEBI:3766",
+        "target_id": "MONDO:0019790",
+        "type": "contraindicated_for"
+      },
+      {
+        "id": "7740549283932957956",
+        "source_id": "CHEBI:70735",
+        "target_id": "MONDO:0019790",
+        "type": "contraindicated_for"
+      },
+      {
+        "id": "789211166546123808",
+        "source_id": "CHEBI:8871",
+        "target_id": "MONDO:0019790",
+        "type": "contraindicated_for"
+      },
+      {
+        "id": "-2096299938036046806",
+        "source_id": "CHEBI:7735",
+        "target_id": "MONDO:0001484",
+        "type": "treats"
+      },
+      {
+        "id": "2880476554265696256",
+        "source_id": "CHEBI:5613",
+        "target_id": "MONDO:0001484",
+        "type": "treats"
+      },
+      {
+        "id": "-3781630710503599698",
+        "source_id": "CHEBI:31236",
+        "target_id": "MONDO:0001484",
+        "type": "treats"
+      },
+      {
+        "id": "-6510810324898532403",
+        "source_id": "CHEBI:10119",
+        "target_id": "MONDO:0001484",
+        "type": "treats"
+      },
+      {
+        "id": "-2965480311127690162",
+        "source_id": "MESH:D013469",
+        "target_id": "MONDO:0001484",
+        "type": "treats"
+      },
+      {
+        "id": "-6246089208031066512",
+        "source_id": "CHEBI:3766",
+        "target_id": "MONDO:0001484",
+        "type": "treats"
+      },
+      {
+        "id": "809868953028379858",
+        "source_id": "MESH:D013881",
+        "target_id": "MONDO:0001484",
+        "type": "treats"
+      },
+      {
+        "id": "7074869925656453683",
+        "source_id": "MESH:D000077582",
+        "target_id": "MONDO:0001484",
+        "type": "treats"
+      },
+      {
+        "id": "6044889957541981138",
+        "source_id": "MESH:D000069470",
+        "target_id": "MONDO:0002025",
+        "type": "treats"
+      },
+      {
+        "id": "-7655276960712430642",
+        "source_id": "CHEBI:31236",
+        "target_id": "MONDO:0002025",
+        "type": "treats"
+      },
+      {
+        "id": "7278140728218197362",
+        "source_id": "MESH:D013881",
+        "target_id": "MONDO:0002025",
+        "type": "treats"
+      },
+      {
+        "id": "5640599220312391597",
+        "source_id": "CHEBI:10119",
+        "target_id": "MONDO:0002025",
+        "type": "treats"
+      },
+      {
+        "id": "4661912403617054766",
+        "source_id": "MESH:D013469",
+        "target_id": "MONDO:0002025",
+        "type": "treats"
+      },
+      {
+        "id": "3515930600984585296",
+        "source_id": "MESH:D008972",
+        "target_id": "MONDO:0002025",
+        "type": "treats"
+      },
+      {
+        "id": "-2947888501328286768",
+        "source_id": "CHEBI:3766",
+        "target_id": "MONDO:0002025",
+        "type": "treats"
+      },
+      {
+        "id": "-3692759765335553882",
+        "source_id": "MESH:D014282",
+        "target_id": "MONDO:0002025",
+        "type": "treats"
+      },
+      {
+        "id": "-8368178927942799853",
+        "source_id": "MESH:D000077582",
+        "target_id": "MONDO:0002025",
+        "type": "treats"
+      },
+      {
+        "id": "-5866291005977195746",
+        "source_id": "MESH:D011433",
+        "target_id": "MONDO:0016058",
+        "type": "contributes_to"
+      },
+      {
+        "id": "-5085644706264843047",
+        "source_id": "MESH:D000069470",
+        "target_id": "MONDO:0016058",
+        "type": "contributes_to"
+      },
+      {
+        "id": "4027528061697825197",
+        "source_id": "CHEBI:31236",
+        "target_id": "MONDO:0016058",
+        "type": "contributes_to"
+      },
+      {
+        "id": "-8977202683983903282",
+        "source_id": "CHEBI:10119",
+        "target_id": "MONDO:0016058",
+        "type": "contributes_to"
+      },
+      {
+        "id": "654521146691683263",
+        "source_id": "MESH:D008653",
+        "target_id": "MONDO:0016058",
+        "type": "contributes_to"
+      },
+      {
+        "id": "-8545993847183275955",
+        "source_id": "MESH:D013469",
+        "target_id": "MONDO:0016058",
+        "type": "contributes_to"
+      },
+      {
+        "id": "5068254169295547258",
+        "source_id": "MESH:D005473",
+        "target_id": "MONDO:0016058",
+        "type": "contributes_to"
+      },
+      {
+        "id": "-7575310183856325831",
+        "source_id": "MESH:D013881",
+        "target_id": "MONDO:0016058",
+        "type": "contributes_to"
+      },
+      {
+        "id": "-1581191021484012398",
+        "source_id": "MESH:D003990",
+        "target_id": "MONDO:0016058",
+        "type": "contributes_to"
+      },
+      {
+        "id": "7566878842991780245",
+        "source_id": "CHEBI:8871",
+        "target_id": "MONDO:0016058",
+        "type": "contributes_to"
+      },
+      {
+        "id": "-4820168873422319684",
+        "source_id": "CHEBI:8707",
+        "target_id": "UMLS:C3665587",
+        "type": "contraindicated_for"
+      },
+      {
+        "id": "-1416976046145964002",
+        "source_id": "CHEBI:7735",
+        "target_id": "UMLS:C3665587",
+        "type": "contraindicated_for"
+      },
+      {
+        "id": "-8709203226392645004",
+        "source_id": "CHEBI:5613",
+        "target_id": "UMLS:C3665587",
+        "type": "contraindicated_for"
+      },
+      {
+        "id": "6179718538818516794",
+        "source_id": "CHEBI:31236",
+        "target_id": "UMLS:C3665587",
+        "type": "contraindicated_for"
+      },
+      {
+        "id": "-75826078698022543",
+        "source_id": "CHEBI:65173",
+        "target_id": "UMLS:C3665587",
+        "type": "contraindicated_for"
+      },
+      {
+        "id": "-1255268251096207807",
+        "source_id": "CHEBI:10119",
+        "target_id": "UMLS:C3665587",
+        "type": "contraindicated_for"
+      },
+      {
+        "id": "-4181854567561921948",
+        "source_id": "CHEBI:3766",
+        "target_id": "UMLS:C3665587",
+        "type": "contraindicated_for"
+      },
+      {
+        "id": "-8941691008586318046",
+        "source_id": "CHEBI:8871",
+        "target_id": "UMLS:C3665587",
+        "type": "contraindicated_for"
+      },
+      {
+        "id": "-5656986478217796426",
+        "source_id": "CHEBI:5613",
+        "target_id": "MONDO:0005478",
+        "type": "contributes_to"
+      },
+      {
+        "id": "-7110906936486429361",
+        "source_id": "CHEBI:10119",
+        "target_id": "MONDO:0005478",
+        "type": "contributes_to"
+      },
+      {
+        "id": "-1467859242207634949",
+        "source_id": "MESH:D011398",
+        "target_id": "MONDO:0005478",
+        "type": "contributes_to"
+      },
+      {
+        "id": "-2297230824344335298",
+        "source_id": "MESH:D008653",
+        "target_id": "MONDO:0005478",
+        "type": "contributes_to"
+      },
+      {
+        "id": "-5898394631341070232",
+        "source_id": "MESH:D013469",
+        "target_id": "MONDO:0005478",
+        "type": "contributes_to"
+      },
+      {
+        "id": "6563824040180032251",
+        "source_id": "MESH:D005473",
+        "target_id": "MONDO:0005478",
+        "type": "contributes_to"
+      },
+      {
+        "id": "6812383251897921924",
+        "source_id": "MESH:D013881",
+        "target_id": "MONDO:0005478",
+        "type": "contributes_to"
+      },
+      {
+        "id": "3084290182600781392",
+        "source_id": "MESH:D014282",
+        "target_id": "MONDO:0005478",
+        "type": "contributes_to"
+      },
+      {
+        "id": "-5246473483780280599",
+        "source_id": "MESH:D000077582",
+        "target_id": "MONDO:0005478",
+        "type": "contributes_to"
+      },
+      {
+        "id": "-1355512535334662944",
+        "source_id": "CHEBI:8871",
+        "target_id": "MONDO:0005478",
+        "type": "contributes_to"
+      },
+      {
+        "id": "-3096155888980392011",
+        "source_id": "MESH:D011433",
+        "target_id": "MONDO:0045057",
+        "type": "contributes_to"
+      },
+      {
+        "id": "-656478724480611462",
+        "source_id": "MESH:D000069470",
+        "target_id": "MONDO:0045057",
+        "type": "contributes_to"
+      },
+      {
+        "id": "-8328219144568932710",
+        "source_id": "MESH:D013881",
+        "target_id": "MONDO:0045057",
+        "type": "contributes_to"
+      },
+      {
+        "id": "1238654946301400555",
+        "source_id": "MESH:D001712",
+        "target_id": "MONDO:0045057",
+        "type": "contributes_to"
+      },
+      {
+        "id": "3907543275431847385",
+        "source_id": "MESH:D011398",
+        "target_id": "MONDO:0045057",
+        "type": "contributes_to"
+      },
+      {
+        "id": "2550684820612963545",
+        "source_id": "MESH:D005473",
+        "target_id": "MONDO:0045057",
+        "type": "contributes_to"
+      },
+      {
+        "id": "4969228005349217352",
+        "source_id": "CHEBI:3766",
+        "target_id": "MONDO:0045057",
+        "type": "contributes_to"
+      },
+      {
+        "id": "4829079192796076469",
+        "source_id": "MESH:D008140",
+        "target_id": "MONDO:0045057",
+        "type": "contributes_to"
+      },
+      {
+        "id": "-596070693411112498",
+        "source_id": "MESH:D014282",
+        "target_id": "MONDO:0045057",
+        "type": "contributes_to"
+      },
+      {
+        "id": "-444417650432890117",
+        "source_id": "MESH:D011352",
+        "target_id": "MONDO:0045057",
+        "type": "contributes_to"
+      },
+      {
+        "id": "8845557262566355390",
+        "source_id": "CHEBI:8871",
+        "target_id": "MONDO:0045057",
+        "type": "contributes_to"
+      },
+      {
+        "id": "4512202911914841252",
+        "source_id": "CHEBI:8707",
+        "target_id": "MONDO:0019790",
+        "type": "causes_adverse_event"
+      },
+      {
+        "id": "-5525280665136049290",
+        "source_id": "CHEBI:7735",
+        "target_id": "MONDO:0019790",
+        "type": "causes_adverse_event"
+      },
+      {
+        "id": "890830977484141548",
+        "source_id": "CHEBI:5613",
+        "target_id": "MONDO:0019790",
+        "type": "causes_adverse_event"
+      },
+      {
+        "id": "-2405426274601481230",
+        "source_id": "CHEBI:31236",
+        "target_id": "MONDO:0019790",
+        "type": "causes_adverse_event"
+      },
+      {
+        "id": "536362018006234249",
+        "source_id": "CHEBI:65173",
+        "target_id": "MONDO:0019790",
+        "type": "causes_adverse_event"
+      },
+      {
+        "id": "1790838186176958393",
+        "source_id": "CHEBI:10119",
+        "target_id": "MONDO:0019790",
+        "type": "causes_adverse_event"
+      },
+      {
+        "id": "1969712760274854286",
+        "source_id": "CHEBI:70735",
+        "target_id": "MONDO:0019790",
+        "type": "causes_adverse_event"
+      },
+      {
+        "id": "749738027475068939",
+        "source_id": "CHEBI:31981",
+        "target_id": "MONDO:0019790",
+        "type": "causes_adverse_event"
+      },
+      {
+        "id": "-1567770065749621750",
+        "source_id": "CHEBI:8871",
+        "target_id": "MONDO:0019790",
+        "type": "causes_adverse_event"
+      },
+      {
+        "id": "-8068557856541243433",
+        "source_id": "CHEBI:8707",
+        "target_id": "MONDO:0024290",
+        "type": "causes_adverse_event"
+      },
+      {
+        "id": "8542822586804373161",
+        "source_id": "CHEBI:7735",
+        "target_id": "MONDO:0024290",
+        "type": "causes_adverse_event"
+      },
+      {
+        "id": "-4707088294444374753",
+        "source_id": "CHEBI:5613",
+        "target_id": "MONDO:0024290",
+        "type": "causes_adverse_event"
+      },
+      {
+        "id": "-6326421212446071515",
+        "source_id": "CHEBI:31236",
+        "target_id": "MONDO:0024290",
+        "type": "causes_adverse_event"
+      },
+      {
+        "id": "4670643061456322902",
+        "source_id": "CHEBI:65173",
+        "target_id": "MONDO:0024290",
+        "type": "causes_adverse_event"
+      },
+      {
+        "id": "-147945709847765882",
+        "source_id": "CHEBI:10119",
+        "target_id": "MONDO:0024290",
+        "type": "causes_adverse_event"
+      },
+      {
+        "id": "7656975687969885487",
+        "source_id": "CHEBI:3766",
+        "target_id": "MONDO:0024290",
+        "type": "causes_adverse_event"
+      },
+      {
+        "id": "-2021766335042953923",
+        "source_id": "CHEBI:8871",
+        "target_id": "MONDO:0024290",
+        "type": "causes_adverse_event"
+      },
+      {
+        "id": "3780122642844902162",
+        "source_id": "CHEBI:8707",
+        "target_id": "MONDO:0004901",
+        "type": "causes_adverse_event"
+      },
+      {
+        "id": "-991557068985754144",
+        "source_id": "CHEBI:7735",
+        "target_id": "MONDO:0004901",
+        "type": "causes_adverse_event"
+      },
+      {
+        "id": "-1117355485937735094",
+        "source_id": "CHEBI:5613",
+        "target_id": "MONDO:0004901",
+        "type": "causes_adverse_event"
+      },
+      {
+        "id": "290163633554340036",
+        "source_id": "CHEBI:31236",
+        "target_id": "MONDO:0004901",
+        "type": "causes_adverse_event"
+      },
+      {
+        "id": "-130708114319489101",
+        "source_id": "CHEBI:65173",
+        "target_id": "MONDO:0004901",
+        "type": "causes_adverse_event"
+      },
+      {
+        "id": "-8785374085166812445",
+        "source_id": "CHEBI:10119",
+        "target_id": "MONDO:0004901",
+        "type": "causes_adverse_event"
+      },
+      {
+        "id": "7590189071645844058",
+        "source_id": "CHEBI:3766",
+        "target_id": "MONDO:0004901",
+        "type": "causes_adverse_event"
+      },
+      {
+        "id": "-4612060353549820728",
+        "source_id": "CHEBI:70735",
+        "target_id": "MONDO:0004901",
+        "type": "causes_adverse_event"
+      },
+      {
+        "id": "-2415909900249058287",
+        "source_id": "CHEBI:31981",
+        "target_id": "MONDO:0004901",
+        "type": "causes_adverse_event"
+      },
+      {
+        "id": "715147255528557996",
+        "source_id": "CHEBI:8871",
+        "target_id": "MONDO:0004901",
+        "type": "causes_adverse_event"
+      },
+      {
+        "id": "-7695570740792934769",
+        "source_id": "CHEBI:7735",
+        "target_id": "MONDO:0006966",
+        "type": "contributes_to"
+      },
+      {
+        "id": "4472155025705701703",
+        "source_id": "MESH:D000069470",
+        "target_id": "MONDO:0006966",
+        "type": "contributes_to"
+      },
+      {
+        "id": "8090437576813410617",
+        "source_id": "CHEBI:5613",
+        "target_id": "MONDO:0006966",
+        "type": "contributes_to"
+      },
+      {
+        "id": "-7776050621177909269",
+        "source_id": "MESH:D013469",
+        "target_id": "MONDO:0006966",
+        "type": "contributes_to"
+      },
+      {
+        "id": "5898689963278938072",
+        "source_id": "MESH:D005473",
+        "target_id": "MONDO:0006966",
+        "type": "contributes_to"
+      },
+      {
+        "id": "-343993704634168217",
+        "source_id": "MESH:D013881",
+        "target_id": "MONDO:0006966",
+        "type": "contributes_to"
+      },
+      {
+        "id": "-6434418878331110940",
+        "source_id": "MESH:C007761",
+        "target_id": "MONDO:0006966",
+        "type": "contributes_to"
+      },
+      {
+        "id": "8005959358780681990",
+        "source_id": "MESH:D000077582",
+        "target_id": "MONDO:0006966",
+        "type": "contributes_to"
+      },
+      {
+        "id": "-8375415938181510877",
+        "source_id": "CHEBI:8871",
+        "target_id": "MONDO:0006966",
+        "type": "contributes_to"
+      },
+      {
+        "id": "-5543314019251124207",
+        "source_id": "CHEBI:8707",
+        "target_id": "MONDO:0003785",
+        "type": "contraindicated_for"
+      },
+      {
+        "id": "3037040147538452399",
+        "source_id": "CHEBI:7735",
+        "target_id": "MONDO:0003785",
+        "type": "contraindicated_for"
+      },
+      {
+        "id": "-7973343595510248423",
+        "source_id": "CHEBI:5613",
+        "target_id": "MONDO:0003785",
+        "type": "contraindicated_for"
+      },
+      {
+        "id": "1151082609200863275",
+        "source_id": "CHEBI:31236",
+        "target_id": "MONDO:0003785",
+        "type": "contraindicated_for"
+      },
+      {
+        "id": "-1493886004187156196",
+        "source_id": "CHEBI:65173",
+        "target_id": "MONDO:0003785",
+        "type": "contraindicated_for"
+      },
+      {
+        "id": "-8390038245075116980",
+        "source_id": "CHEBI:10119",
+        "target_id": "MONDO:0003785",
+        "type": "contraindicated_for"
+      },
+      {
+        "id": "7172847571873268777",
+        "source_id": "CHEBI:3766",
+        "target_id": "MONDO:0003785",
+        "type": "contraindicated_for"
+      },
+      {
+        "id": "-3478436096299504185",
+        "source_id": "CHEBI:70735",
+        "target_id": "MONDO:0003785",
+        "type": "contraindicated_for"
+      },
+      {
+        "id": "5864746648622600259",
+        "source_id": "CHEBI:8871",
+        "target_id": "MONDO:0003785",
+        "type": "contraindicated_for"
+      },
+      {
+        "id": "-6475079625806153041",
+        "source_id": "CHEBI:8707",
+        "target_id": "MONDO:0010096",
+        "type": "causes_adverse_event"
+      },
+      {
+        "id": "-5291820913262841071",
+        "source_id": "CHEBI:7735",
+        "target_id": "MONDO:0010096",
+        "type": "causes_adverse_event"
+      },
+      {
+        "id": "-1699485868356524057",
+        "source_id": "CHEBI:5613",
+        "target_id": "MONDO:0010096",
+        "type": "causes_adverse_event"
+      },
+      {
+        "id": "-2659774116088053971",
+        "source_id": "CHEBI:31236",
+        "target_id": "MONDO:0010096",
+        "type": "causes_adverse_event"
+      },
+      {
+        "id": "-4636235250064105858",
+        "source_id": "CHEBI:65173",
+        "target_id": "MONDO:0010096",
+        "type": "causes_adverse_event"
+      },
+      {
+        "id": "477007404452135758",
+        "source_id": "CHEBI:10119",
+        "target_id": "MONDO:0010096",
+        "type": "causes_adverse_event"
+      },
+      {
+        "id": "3316143687829002233",
+        "source_id": "CHEBI:70735",
+        "target_id": "MONDO:0010096",
+        "type": "causes_adverse_event"
+      },
+      {
+        "id": "7571025181304214549",
+        "source_id": "CHEBI:8871",
+        "target_id": "MONDO:0010096",
+        "type": "causes_adverse_event"
+      },
+      {
+        "id": "8151367887479310133",
+        "source_id": "MESH:D000069470",
+        "target_id": "MONDO:0005146",
+        "type": "treats"
+      },
+      {
+        "id": "6242426350546455277",
+        "source_id": "CHEBI:7735",
+        "target_id": "MONDO:0005146",
+        "type": "treats"
+      },
+      {
+        "id": "6680602685400644629",
+        "source_id": "MESH:D013881",
+        "target_id": "MONDO:0005146",
+        "type": "treats"
+      },
+      {
+        "id": "4614858993641184753",
+        "source_id": "MESH:D013469",
+        "target_id": "MONDO:0005146",
+        "type": "treats"
+      },
+      {
+        "id": "8892907267196242590",
+        "source_id": "MESH:D005473",
+        "target_id": "MONDO:0005146",
+        "type": "treats"
+      },
+      {
+        "id": "1691533969603075578",
+        "source_id": "MESH:D008140",
+        "target_id": "MONDO:0005146",
+        "type": "treats"
+      },
+      {
+        "id": "-1321249648166313799",
+        "source_id": "CHEBI:8871",
+        "target_id": "MONDO:0005146",
+        "type": "treats"
+      },
+      {
+        "id": "3382542443408984595",
+        "source_id": "CHEBI:7735",
+        "target_id": "HP:0001662",
+        "type": "contributes_to"
+      },
+      {
+        "id": "3914709103277830391",
+        "source_id": "CHEBI:31236",
+        "target_id": "HP:0001662",
+        "type": "contributes_to"
+      },
+      {
+        "id": "-6448075984934064950",
+        "source_id": "MESH:D001712",
+        "target_id": "HP:0001662",
+        "type": "contributes_to"
+      },
+      {
+        "id": "533851379061900976",
+        "source_id": "CHEBI:10119",
+        "target_id": "HP:0001662",
+        "type": "contributes_to"
+      },
+      {
+        "id": "2485370548408504772",
+        "source_id": "MESH:D011398",
+        "target_id": "HP:0001662",
+        "type": "contributes_to"
+      },
+      {
+        "id": "502915809376163867",
+        "source_id": "MESH:D012906",
+        "target_id": "HP:0001662",
+        "type": "contributes_to"
+      },
+      {
+        "id": "4633906128651013773",
+        "source_id": "CHEBI:3766",
+        "target_id": "HP:0001662",
+        "type": "contributes_to"
+      },
+      {
+        "id": "-3699738814561811808",
+        "source_id": "MESH:D008140",
+        "target_id": "HP:0001662",
+        "type": "contributes_to"
+      },
+      {
+        "id": "8529029421556101359",
+        "source_id": "MESH:D014282",
+        "target_id": "HP:0001662",
+        "type": "contributes_to"
+      },
+      {
+        "id": "-7342722676319400886",
+        "source_id": "MESH:D000077582",
+        "target_id": "HP:0001662",
+        "type": "contributes_to"
+      },
+      {
+        "id": "8969528000965101023",
+        "source_id": "CHEBI:8871",
+        "target_id": "HP:0001662",
+        "type": "contributes_to"
+      },
+      {
+        "id": "-1886762736391704635",
+        "source_id": "MESH:D011433",
+        "target_id": "MONDO:0005640",
+        "type": "contributes_to"
+      },
+      {
+        "id": "-4075516581501838766",
+        "source_id": "CHEBI:7735",
+        "target_id": "MONDO:0005640",
+        "type": "contributes_to"
+      },
+      {
+        "id": "-7909593984536737112",
+        "source_id": "CHEBI:5613",
+        "target_id": "MONDO:0005640",
+        "type": "contributes_to"
+      },
+      {
+        "id": "8459921619798609578",
+        "source_id": "MESH:D013881",
+        "target_id": "MONDO:0005640",
+        "type": "contributes_to"
+      },
+      {
+        "id": "6000514696491204873",
+        "source_id": "MESH:D011398",
+        "target_id": "MONDO:0005640",
+        "type": "contributes_to"
+      },
+      {
+        "id": "-1929211694600666960",
+        "source_id": "MESH:D008653",
+        "target_id": "MONDO:0005640",
+        "type": "contributes_to"
+      },
+      {
+        "id": "-8433299558252010856",
+        "source_id": "CHEBI:3766",
+        "target_id": "MONDO:0005640",
+        "type": "contributes_to"
+      },
+      {
+        "id": "-1263327851930119739",
+        "source_id": "MESH:D008140",
+        "target_id": "MONDO:0005640",
+        "type": "contributes_to"
+      },
+      {
+        "id": "-369958072781298469",
+        "source_id": "MESH:D000077582",
+        "target_id": "MONDO:0005640",
+        "type": "contributes_to"
+      },
+      {
+        "id": "45547578499009774",
+        "source_id": "CHEBI:8871",
+        "target_id": "MONDO:0005640",
+        "type": "contributes_to"
+      },
+      {
+        "id": "1807084107643763941",
+        "source_id": "CHEBI:7735",
+        "target_id": "MONDO:0002265",
+        "type": "treats"
+      },
+      {
+        "id": "-1621385507383895139",
+        "source_id": "MESH:D000069470",
+        "target_id": "MONDO:0002265",
+        "type": "treats"
+      },
+      {
+        "id": "5256552198841176169",
+        "source_id": "CHEBI:31236",
+        "target_id": "MONDO:0002265",
+        "type": "treats"
+      },
+      {
+        "id": "2219163019593104585",
+        "source_id": "MESH:D013469",
+        "target_id": "MONDO:0002265",
+        "type": "treats"
+      },
+      {
+        "id": "-632655828542236565",
+        "source_id": "CHEBI:3766",
+        "target_id": "MONDO:0002265",
+        "type": "treats"
+      },
+      {
+        "id": "2076692700165479703",
+        "source_id": "MESH:C030265",
+        "target_id": "MONDO:0002265",
+        "type": "treats"
+      },
+      {
+        "id": "5473425858982591361",
+        "source_id": "CHEBI:8871",
+        "target_id": "MONDO:0002265",
+        "type": "treats"
+      },
+      {
+        "id": "-2007823561432491652",
+        "source_id": "MESH:D011433",
+        "target_id": "MONDO:0005395",
+        "type": "contributes_to"
+      },
+      {
+        "id": "8190705034527981799",
+        "source_id": "MESH:D000069470",
+        "target_id": "MONDO:0005395",
+        "type": "contributes_to"
+      },
+      {
+        "id": "-5993017496814361767",
+        "source_id": "CHEBI:5613",
+        "target_id": "MONDO:0005395",
+        "type": "contributes_to"
+      },
+      {
+        "id": "-3954255148019272249",
+        "source_id": "MESH:D013881",
+        "target_id": "MONDO:0005395",
+        "type": "contributes_to"
+      },
+      {
+        "id": "-3864173807480859764",
+        "source_id": "CHEBI:10119",
+        "target_id": "MONDO:0005395",
+        "type": "contributes_to"
+      },
+      {
+        "id": "-6425529449743513845",
+        "source_id": "MESH:D013469",
+        "target_id": "MONDO:0005395",
+        "type": "contributes_to"
+      },
+      {
+        "id": "-2971200935219760456",
+        "source_id": "MESH:D005473",
+        "target_id": "MONDO:0005395",
+        "type": "contributes_to"
+      },
+      {
+        "id": "-9200739895670295319",
+        "source_id": "CHEBI:3766",
+        "target_id": "MONDO:0005395",
+        "type": "contributes_to"
+      },
+      {
+        "id": "3131905890862032764",
+        "source_id": "MESH:D008140",
+        "target_id": "MONDO:0005395",
+        "type": "contributes_to"
+      },
+      {
+        "id": "351082519169215044",
+        "source_id": "MESH:C007761",
+        "target_id": "MONDO:0005395",
+        "type": "contributes_to"
+      },
+      {
+        "id": "516356348138027267",
+        "source_id": "CHEBI:8871",
+        "target_id": "MONDO:0005395",
+        "type": "contributes_to"
+      },
+      {
+        "id": "95600692469403897",
+        "source_id": "MESH:D011433",
+        "target_id": "MONDO:0005359",
+        "type": "contributes_to"
+      },
+      {
+        "id": "2448480368402111366",
+        "source_id": "CHEBI:7735",
+        "target_id": "MONDO:0005359",
+        "type": "contributes_to"
+      },
+      {
+        "id": "4679019237365139198",
+        "source_id": "MESH:D000069470",
+        "target_id": "MONDO:0005359",
+        "type": "contributes_to"
+      },
+      {
+        "id": "3458782188535442396",
+        "source_id": "CHEBI:5613",
+        "target_id": "MONDO:0005359",
+        "type": "contributes_to"
+      },
+      {
+        "id": "3505740920049695710",
+        "source_id": "MESH:D013881",
+        "target_id": "MONDO:0005359",
+        "type": "contributes_to"
+      },
+      {
+        "id": "-173816170914167545",
+        "source_id": "MESH:C515050",
+        "target_id": "MONDO:0005359",
+        "type": "contributes_to"
+      },
+      {
+        "id": "6622030668805218261",
+        "source_id": "MESH:D011398",
+        "target_id": "MONDO:0005359",
+        "type": "contributes_to"
+      },
+      {
+        "id": "-4207176033649706558",
+        "source_id": "MESH:D013469",
+        "target_id": "MONDO:0005359",
+        "type": "contributes_to"
+      },
+      {
+        "id": "-1324873587069704642",
+        "source_id": "MESH:D012906",
+        "target_id": "MONDO:0005359",
+        "type": "contributes_to"
+      },
+      {
+        "id": "-6575588889842842676",
+        "source_id": "CHEBI:3766",
+        "target_id": "MONDO:0005359",
+        "type": "contributes_to"
+      },
+      {
+        "id": "899962618160977621",
+        "source_id": "MESH:D005473",
+        "target_id": "MONDO:0005359",
+        "type": "contributes_to"
+      },
+      {
+        "id": "7419949375625482410",
+        "source_id": "MESH:D014282",
+        "target_id": "MONDO:0005359",
+        "type": "contributes_to"
+      },
+      {
+        "id": "-6781348368462337094",
+        "source_id": "CHEBI:8871",
+        "target_id": "MONDO:0005359",
+        "type": "contributes_to"
+      },
+      {
+        "id": "3414135163758255509",
+        "source_id": "CHEBI:8707",
+        "target_id": "MONDO:0003233",
+        "type": "causes_adverse_event"
+      },
+      {
+        "id": "-6093103728374067517",
+        "source_id": "CHEBI:7735",
+        "target_id": "MONDO:0003233",
+        "type": "causes_adverse_event"
+      },
+      {
+        "id": "1390338507571581389",
+        "source_id": "CHEBI:5613",
+        "target_id": "MONDO:0003233",
+        "type": "causes_adverse_event"
+      },
+      {
+        "id": "3672488302189657159",
+        "source_id": "CHEBI:31236",
+        "target_id": "MONDO:0003233",
+        "type": "causes_adverse_event"
+      },
+      {
+        "id": "-1522931296995803856",
+        "source_id": "CHEBI:65173",
+        "target_id": "MONDO:0003233",
+        "type": "causes_adverse_event"
+      },
+      {
+        "id": "-7622948537027898880",
+        "source_id": "CHEBI:10119",
+        "target_id": "MONDO:0003233",
+        "type": "causes_adverse_event"
+      },
+      {
+        "id": "-2859151584559806805",
+        "source_id": "CHEBI:70735",
+        "target_id": "MONDO:0003233",
+        "type": "causes_adverse_event"
+      },
+      {
+        "id": "-916651110502222290",
+        "source_id": "CHEBI:31981",
+        "target_id": "MONDO:0003233",
+        "type": "causes_adverse_event"
+      },
+      {
+        "id": "5059503884894913583",
+        "source_id": "CHEBI:8871",
+        "target_id": "MONDO:0003233",
+        "type": "causes_adverse_event"
+      },
+      {
+        "id": "-4479439093956043075",
+        "source_id": "CHEBI:8707",
+        "target_id": "MONDO:0002050",
+        "type": "treats"
+      },
+      {
+        "id": "-2273592518372039077",
+        "source_id": "CHEBI:7735",
+        "target_id": "MONDO:0002050",
+        "type": "treats"
+      },
+      {
+        "id": "-7405020777115070913",
+        "source_id": "CHEBI:31236",
+        "target_id": "MONDO:0002050",
+        "type": "treats"
+      },
+      {
+        "id": "-8107549427554054062",
+        "source_id": "MESH:D001712",
+        "target_id": "MONDO:0002050",
+        "type": "treats"
+      },
+      {
+        "id": "2196118760754651698",
+        "source_id": "MESH:D012436",
+        "target_id": "MONDO:0002050",
+        "type": "treats"
+      },
+      {
+        "id": "-825645177523714017",
+        "source_id": "MESH:D013469",
+        "target_id": "MONDO:0002050",
+        "type": "treats"
+      },
+      {
+        "id": "-3159421616328477133",
+        "source_id": "MESH:D013881",
+        "target_id": "MONDO:0002050",
+        "type": "treats"
+      },
+      {
+        "id": "-252890658072196688",
+        "source_id": "MESH:C007761",
+        "target_id": "MONDO:0002050",
+        "type": "treats"
+      },
+      {
+        "id": "5918520347873757394",
+        "source_id": "MESH:D000077582",
+        "target_id": "MONDO:0002050",
+        "type": "treats"
+      },
+      {
+        "id": "-6410622664977230762",
+        "source_id": "CHEBI:5613",
+        "target_id": "MONDO:0005485",
+        "type": "treats"
+      },
+      {
+        "id": "7169429819460581860",
+        "source_id": "MESH:D013881",
+        "target_id": "MONDO:0005485",
+        "type": "treats"
+      },
+      {
+        "id": "6313309424769656585",
+        "source_id": "MESH:D001712",
+        "target_id": "MONDO:0005485",
+        "type": "treats"
+      },
+      {
+        "id": "1162435995179776008",
+        "source_id": "MESH:D013469",
+        "target_id": "MONDO:0005485",
+        "type": "treats"
+      },
+      {
+        "id": "2129885142373066310",
+        "source_id": "MESH:D008972",
+        "target_id": "MONDO:0005485",
+        "type": "treats"
+      },
+      {
+        "id": "-2901908578201071617",
+        "source_id": "MESH:D008140",
+        "target_id": "MONDO:0005485",
+        "type": "treats"
+      },
+      {
+        "id": "4431982969745312871",
+        "source_id": "MESH:C007761",
+        "target_id": "MONDO:0005485",
+        "type": "treats"
+      },
+      {
+        "id": "4837347622653324937",
+        "source_id": "MESH:D000077582",
+        "target_id": "MONDO:0005485",
+        "type": "treats"
+      },
+      {
+        "id": "7833007451189389640",
+        "source_id": "CHEBI:8707",
+        "target_id": "MONDO:0005804",
+        "type": "causes_adverse_event"
+      },
+      {
+        "id": "8853877195794649514",
+        "source_id": "CHEBI:7735",
+        "target_id": "MONDO:0005804",
+        "type": "causes_adverse_event"
+      },
+      {
+        "id": "-2300638039554984320",
+        "source_id": "CHEBI:5613",
+        "target_id": "MONDO:0005804",
+        "type": "causes_adverse_event"
+      },
+      {
+        "id": "-4177584470336582610",
+        "source_id": "CHEBI:31236",
+        "target_id": "MONDO:0005804",
+        "type": "causes_adverse_event"
+      },
+      {
+        "id": "961782262926722637",
+        "source_id": "CHEBI:10119",
+        "target_id": "MONDO:0005804",
+        "type": "causes_adverse_event"
+      },
+      {
+        "id": "5966198749260424432",
+        "source_id": "CHEBI:3766",
+        "target_id": "MONDO:0005804",
+        "type": "causes_adverse_event"
+      },
+      {
+        "id": "3115079032542798102",
+        "source_id": "CHEBI:8871",
+        "target_id": "MONDO:0005804",
+        "type": "causes_adverse_event"
+      },
+      {
+        "id": "-1757460190812366426",
+        "source_id": "CHEBI:8707",
+        "target_id": "MONDO:0005469",
+        "type": "contraindicated_for"
+      },
+      {
+        "id": "-8811129079244630924",
+        "source_id": "CHEBI:7735",
+        "target_id": "MONDO:0005469",
+        "type": "contraindicated_for"
+      },
+      {
+        "id": "-2663754149609806096",
+        "source_id": "CHEBI:31236",
+        "target_id": "MONDO:0005469",
+        "type": "contraindicated_for"
+      },
+      {
+        "id": "1917879541043216263",
+        "source_id": "CHEBI:65173",
+        "target_id": "MONDO:0005469",
+        "type": "contraindicated_for"
+      },
+      {
+        "id": "6363292418905172663",
+        "source_id": "CHEBI:10119",
+        "target_id": "MONDO:0005469",
+        "type": "contraindicated_for"
+      },
+      {
+        "id": "5988279711666690606",
+        "source_id": "CHEBI:3766",
+        "target_id": "MONDO:0005469",
+        "type": "contraindicated_for"
+      },
+      {
+        "id": "3833623213098875228",
+        "source_id": "CHEBI:70735",
+        "target_id": "MONDO:0005469",
+        "type": "contraindicated_for"
+      },
+      {
+        "id": "8485690120326003672",
+        "source_id": "CHEBI:8871",
+        "target_id": "MONDO:0005469",
+        "type": "contraindicated_for"
+      },
+      {
+        "id": "dfd0579f-ed83-4cd1-b1fd-018dc45d0aa0",
+        "source_id": "MONDO:0005090",
+        "target_id": "MONDO:0005090",
+        "type": "literature_co-occurrence",
+        "source_database": "omnicorp",
+        "publications": [],
+        "num_publications": 138473,
+        "edge_source": "omnicorp.term_to_term"
+      },
+      {
+        "id": "ac91e8d3-25b2-4a33-a705-53bb9e992169",
+        "source_id": "MESH:D011433",
+        "target_id": "MONDO:0005090",
+        "type": "literature_co-occurrence",
+        "source_database": "omnicorp",
+        "publications": [],
+        "num_publications": 146,
+        "edge_source": "omnicorp.term_to_term"
+      },
+      {
+        "id": "1d8103c5-ec7f-4113-b748-a831f50348ec",
+        "source_id": "MESH:D013469",
+        "target_id": "MONDO:0005090",
+        "type": "literature_co-occurrence",
+        "source_database": "omnicorp",
+        "publications": [],
+        "num_publications": 560,
+        "edge_source": "omnicorp.term_to_term"
+      },
+      {
+        "id": "10cc973f-a2c3-425a-88fc-053d40f9d05c",
+        "source_id": "MESH:D008140",
+        "target_id": "MONDO:0005090",
+        "type": "literature_co-occurrence",
+        "source_database": "omnicorp",
+        "publications": [],
+        "num_publications": 134,
+        "edge_source": "omnicorp.term_to_term"
+      },
+      {
+        "id": "6dcc0290-4a57-4641-841e-7b7bce0c4dfa",
+        "source_id": "MESH:D003990",
+        "target_id": "MONDO:0005090",
+        "type": "literature_co-occurrence",
+        "source_database": "omnicorp",
+        "publications": [],
+        "num_publications": 9,
+        "edge_source": "omnicorp.term_to_term"
+      },
+      {
+        "id": "785dec49-b2e6-4aed-a3d4-3ccf5ef5ba9a",
+        "source_id": "MESH:D011352",
+        "target_id": "MONDO:0005090",
+        "type": "literature_co-occurrence",
+        "source_database": "omnicorp",
+        "publications": [],
+        "num_publications": 51,
+        "edge_source": "omnicorp.term_to_term"
+      },
+      {
+        "id": "0ed76ed3-1ae6-4f2b-90b6-5af65e71863e",
+        "source_id": "MESH:D000069470",
+        "target_id": "MONDO:0005090",
+        "type": "literature_co-occurrence",
+        "source_database": "omnicorp",
+        "publications": [],
+        "num_publications": 19,
+        "edge_source": "omnicorp.term_to_term"
+      },
+      {
+        "id": "92bd59d3-ae8b-4d45-b4be-c9edc87fffb9",
+        "source_id": "MESH:D001712",
+        "target_id": "MONDO:0005090",
+        "type": "literature_co-occurrence",
+        "source_database": "omnicorp",
+        "publications": [],
+        "num_publications": 106,
+        "edge_source": "omnicorp.term_to_term"
+      },
+      {
+        "id": "4d694c72-5629-4e7b-9210-3feb7d892a36",
+        "source_id": "MESH:D012436",
+        "target_id": "MONDO:0005090",
+        "type": "literature_co-occurrence",
+        "source_database": "omnicorp",
+        "publications": [],
+        "num_publications": 41,
+        "edge_source": "omnicorp.term_to_term"
+      },
+      {
+        "id": "f235abe9-d66c-4777-aa7a-0b7c25a56a83",
+        "source_id": "MESH:D008972",
+        "target_id": "MONDO:0005090",
+        "type": "literature_co-occurrence",
+        "source_database": "omnicorp",
+        "publications": [],
+        "num_publications": 59,
+        "edge_source": "omnicorp.term_to_term"
+      },
+      {
+        "id": "b700e850-b64b-4b7c-b2ae-0bad66f71a3e",
+        "source_id": "MESH:C030265",
+        "target_id": "MONDO:0005090",
+        "type": "literature_co-occurrence",
+        "source_database": "omnicorp",
+        "publications": [],
+        "num_publications": 30,
+        "edge_source": "omnicorp.term_to_term"
+      },
+      {
+        "id": "c52e233d-3864-4615-afb9-6fb1103a22a9",
+        "source_id": "MESH:C522667",
+        "target_id": "MONDO:0005090",
+        "type": "literature_co-occurrence",
+        "source_database": "omnicorp",
+        "publications": [],
+        "num_publications": 113,
+        "edge_source": "omnicorp.term_to_term"
+      },
+      {
+        "id": "a782b019-3deb-4df6-8e5f-a5e00606d2bf",
+        "source_id": "MESH:D011398",
+        "target_id": "MONDO:0005090",
+        "type": "literature_co-occurrence",
+        "source_database": "omnicorp",
+        "publications": [],
+        "num_publications": 28,
+        "edge_source": "omnicorp.term_to_term"
+      },
+      {
+        "id": "33f47eee-3df3-44e6-a794-6c0afb0c5e5b",
+        "source_id": "MESH:D008653",
+        "target_id": "MONDO:0005090",
+        "type": "literature_co-occurrence",
+        "source_database": "omnicorp",
+        "publications": [],
+        "num_publications": 32,
+        "edge_source": "omnicorp.term_to_term"
+      },
+      {
+        "id": "9392cd8f-8cf6-465a-bb1f-5af5a9db2690",
+        "source_id": "MESH:D012906",
+        "target_id": "MONDO:0005090",
+        "type": "literature_co-occurrence",
+        "source_database": "omnicorp",
+        "publications": [],
+        "num_publications": 5,
+        "edge_source": "omnicorp.term_to_term"
+      },
+      {
+        "id": "d5dbfcb3-012b-4a93-b08d-7977d3227c2b",
+        "source_id": "MESH:D005473",
+        "target_id": "MONDO:0005090",
+        "type": "literature_co-occurrence",
+        "source_database": "omnicorp",
+        "publications": [],
+        "num_publications": 114,
+        "edge_source": "omnicorp.term_to_term"
+      },
+      {
+        "id": "14b13cae-5681-41a6-9bd2-b5b5fec969a3",
+        "source_id": "MESH:C100234",
+        "target_id": "MONDO:0005090",
+        "type": "literature_co-occurrence",
+        "source_database": "omnicorp",
+        "publications": [],
+        "num_publications": 2,
+        "edge_source": "omnicorp.term_to_term"
+      },
+      {
+        "id": "04c630e7-f050-436a-bd3b-cc9ab8d370a3",
+        "source_id": "MESH:D013881",
+        "target_id": "MONDO:0005090",
+        "type": "literature_co-occurrence",
+        "source_database": "omnicorp",
+        "publications": [],
+        "num_publications": 454,
+        "edge_source": "omnicorp.term_to_term"
+      },
+      {
+        "id": "a59f79ae-261d-464d-bdd1-b42a2ef73bcf",
+        "source_id": "MESH:C060342",
+        "target_id": "MONDO:0005090",
+        "type": "literature_co-occurrence",
+        "source_database": "omnicorp",
+        "publications": [],
+        "num_publications": 12,
+        "edge_source": "omnicorp.term_to_term"
+      },
+      {
+        "id": "90b99036-281c-47a0-af2e-22722581baf5",
+        "source_id": "MESH:C515050",
+        "target_id": "MONDO:0005090",
+        "type": "literature_co-occurrence",
+        "source_database": "omnicorp",
+        "publications": [],
+        "num_publications": 7,
+        "edge_source": "omnicorp.term_to_term"
+      },
+      {
+        "id": "ad82daf4-f7d4-4b7a-ab61-a6521ac60cac",
+        "source_id": "MESH:D014282",
+        "target_id": "MONDO:0005090",
+        "type": "literature_co-occurrence",
+        "source_database": "omnicorp",
+        "publications": [],
+        "num_publications": 114,
+        "edge_source": "omnicorp.term_to_term"
+      },
+      {
+        "id": "a1d12a86-1869-40c0-b989-7dddb20fd3e3",
+        "source_id": "MESH:C007761",
+        "target_id": "MONDO:0005090",
+        "type": "literature_co-occurrence",
+        "source_database": "omnicorp",
+        "publications": [],
+        "num_publications": 64,
+        "edge_source": "omnicorp.term_to_term"
+      },
+      {
+        "id": "4c101a2b-dcd8-4ef5-833f-3bd6633e1ceb",
+        "source_id": "MESH:D000077582",
+        "target_id": "MONDO:0005090",
+        "type": "literature_co-occurrence",
+        "source_database": "omnicorp",
+        "publications": [],
+        "num_publications": 381,
+        "edge_source": "omnicorp.term_to_term"
+      },
+      {
+        "id": "6fea48cb-3947-4d71-a38a-ade9fbfaf945",
+        "source_id": "MONDO:0004985",
+        "target_id": "MONDO:0005090",
+        "type": "literature_co-occurrence",
+        "source_database": "omnicorp",
+        "publications": [],
+        "num_publications": 2,
+        "edge_source": "omnicorp.term_to_term"
+      },
+      {
+        "id": "4f6bc436-44c3-4d60-a836-21075ce40186",
+        "source_id": "MESH:D014282",
+        "target_id": "MONDO:0004985",
+        "type": "literature_co-occurrence",
+        "source_database": "omnicorp",
+        "publications": [],
+        "num_publications": 11,
+        "edge_source": "omnicorp.term_to_term"
+      },
+      {
+        "id": "a7356a59-17ee-4fa2-8eaf-1b8bd795d8ec",
+        "source_id": "MESH:D001712",
+        "target_id": "MONDO:0004985",
+        "type": "literature_co-occurrence",
+        "source_database": "omnicorp",
+        "publications": [],
+        "num_publications": 4,
+        "edge_source": "omnicorp.term_to_term"
+      },
+      {
+        "id": "32e73478-16d0-4fa2-808a-5bdb696bc4e8",
+        "source_id": "MESH:D011398",
+        "target_id": "MONDO:0004985",
+        "type": "literature_co-occurrence",
+        "source_database": "omnicorp",
+        "publications": [],
+        "num_publications": 4,
+        "edge_source": "omnicorp.term_to_term"
+      },
+      {
+        "id": "12c096b5-fb5c-4548-90e4-240d1f6f45ce",
+        "source_id": "MESH:D008653",
+        "target_id": "MONDO:0004985",
+        "type": "literature_co-occurrence",
+        "source_database": "omnicorp",
+        "publications": [],
+        "num_publications": 3,
+        "edge_source": "omnicorp.term_to_term"
+      },
+      {
+        "id": "25b66ce3-bdab-40f9-8f6f-1884448a7738",
+        "source_id": "MESH:D013469",
+        "target_id": "MONDO:0004985",
+        "type": "literature_co-occurrence",
+        "source_database": "omnicorp",
+        "publications": [],
+        "num_publications": 39,
+        "edge_source": "omnicorp.term_to_term"
+      },
+      {
+        "id": "466f214d-a79d-41fb-aaf0-03216d0e304f",
+        "source_id": "MESH:D005473",
+        "target_id": "MONDO:0004985",
+        "type": "literature_co-occurrence",
+        "source_database": "omnicorp",
+        "publications": [],
+        "num_publications": 217,
+        "edge_source": "omnicorp.term_to_term"
+      },
+      {
+        "id": "22265ef9-6d7e-4cb4-8857-8c0910ff2bc3",
+        "source_id": "MESH:D013881",
+        "target_id": "MONDO:0004985",
+        "type": "literature_co-occurrence",
+        "source_database": "omnicorp",
+        "publications": [],
+        "num_publications": 83,
+        "edge_source": "omnicorp.term_to_term"
+      },
+      {
+        "id": "7218b1f7-b1fc-48cd-83ef-47c9a9728832",
+        "source_id": "MESH:D011352",
+        "target_id": "MONDO:0004985",
+        "type": "literature_co-occurrence",
+        "source_database": "omnicorp",
+        "publications": [],
+        "num_publications": 10,
+        "edge_source": "omnicorp.term_to_term"
+      },
+      {
+        "id": "c70e3932-1f28-48cf-80ac-1b3359d91c28",
+        "source_id": "MESH:D013881",
+        "target_id": "MONDO:0011552",
+        "type": "literature_co-occurrence",
+        "source_database": "omnicorp",
+        "publications": [],
+        "num_publications": 14,
+        "edge_source": "omnicorp.term_to_term"
+      },
+      {
+        "id": "2cd2b487-428d-4416-b238-3e4c2bda43fd",
+        "source_id": "MESH:D008140",
+        "target_id": "MONDO:0011552",
+        "type": "literature_co-occurrence",
+        "source_database": "omnicorp",
+        "publications": [],
+        "num_publications": 32,
+        "edge_source": "omnicorp.term_to_term"
+      },
+      {
+        "id": "89b8696d-cf7b-4c32-8c8a-d99baf56f4bd",
+        "source_id": "MESH:D000069470",
+        "target_id": "MONDO:0019790",
+        "type": "literature_co-occurrence",
+        "source_database": "omnicorp",
+        "publications": [],
+        "num_publications": 9,
+        "edge_source": "omnicorp.term_to_term"
+      },
+      {
+        "id": "b0b92e9a-b0ad-449b-8423-3ba9c197c308",
+        "source_id": "MESH:D013881",
+        "target_id": "MONDO:0019790",
+        "type": "literature_co-occurrence",
+        "source_database": "omnicorp",
+        "publications": [],
+        "num_publications": 25,
+        "edge_source": "omnicorp.term_to_term"
+      },
+      {
+        "id": "46f1c3f1-5cfb-40be-b55f-c30eb1d18190",
+        "source_id": "MESH:D011398",
+        "target_id": "MONDO:0019790",
+        "type": "literature_co-occurrence",
+        "source_database": "omnicorp",
+        "publications": [],
+        "num_publications": 9,
+        "edge_source": "omnicorp.term_to_term"
+      },
+      {
+        "id": "c2b3561c-998a-44ef-8a8e-7f1d9adaceb2",
+        "source_id": "MESH:D000077582",
+        "target_id": "MONDO:0019790",
+        "type": "literature_co-occurrence",
+        "source_database": "omnicorp",
+        "publications": [],
+        "num_publications": 16,
+        "edge_source": "omnicorp.term_to_term"
+      },
+      {
+        "id": "3253a02d-e41f-4000-bd66-e045c2dd0ed1",
+        "source_id": "MESH:D008972",
+        "target_id": "MONDO:0019790",
+        "type": "literature_co-occurrence",
+        "source_database": "omnicorp",
+        "publications": [],
+        "num_publications": 3,
+        "edge_source": "omnicorp.term_to_term"
+      },
+      {
+        "id": "ccda52b7-7adc-4c0c-9fc7-2d8ea3bc2f1c",
+        "source_id": "MESH:C007761",
+        "target_id": "MONDO:0019790",
+        "type": "literature_co-occurrence",
+        "source_database": "omnicorp",
+        "publications": [],
+        "num_publications": 3,
+        "edge_source": "omnicorp.term_to_term"
+      },
+      {
+        "id": "da172c1d-6577-4b6c-adb7-be48564bc5cc",
+        "source_id": "MESH:D011352",
+        "target_id": "MONDO:0019790",
+        "type": "literature_co-occurrence",
+        "source_database": "omnicorp",
+        "publications": [],
+        "num_publications": 5,
+        "edge_source": "omnicorp.term_to_term"
+      },
+      {
+        "id": "2d4f57ea-b890-4c05-ab13-7106b9018897",
+        "source_id": "MESH:D000069470",
+        "target_id": "MONDO:0005804",
+        "type": "literature_co-occurrence",
+        "source_database": "omnicorp",
+        "publications": [],
+        "num_publications": 2,
+        "edge_source": "omnicorp.term_to_term"
+      },
+      {
+        "id": "133c768b-21ae-4c00-976d-012d980a24c1",
+        "source_id": "MESH:D013881",
+        "target_id": "MONDO:0005804",
+        "type": "literature_co-occurrence",
+        "source_database": "omnicorp",
+        "publications": [],
+        "num_publications": 5,
+        "edge_source": "omnicorp.term_to_term"
+      },
+      {
+        "id": "8c81633e-4c79-4065-9cad-e155bde1af22",
+        "source_id": "MESH:D013469",
+        "target_id": "MONDO:0005804",
+        "type": "literature_co-occurrence",
+        "source_database": "omnicorp",
+        "publications": [],
+        "num_publications": 162,
+        "edge_source": "omnicorp.term_to_term"
+      },
+      {
+        "id": "d17e8e91-3c7c-4d85-bd97-b93d770a9a43",
+        "source_id": "MESH:D005473",
+        "target_id": "MONDO:0005804",
+        "type": "literature_co-occurrence",
+        "source_database": "omnicorp",
+        "publications": [],
+        "num_publications": 9,
+        "edge_source": "omnicorp.term_to_term"
+      },
+      {
+        "id": "c1a7a0ec-712f-4d42-9f82-aea353340778",
+        "source_id": "MESH:D008972",
+        "target_id": "MONDO:0005804",
+        "type": "literature_co-occurrence",
+        "source_database": "omnicorp",
+        "publications": [],
+        "num_publications": 2,
+        "edge_source": "omnicorp.term_to_term"
+      },
+      {
+        "id": "363afc69-9a96-467a-904f-3f6a001adad0",
+        "source_id": "MESH:D000077582",
+        "target_id": "MONDO:0005804",
+        "type": "literature_co-occurrence",
+        "source_database": "omnicorp",
+        "publications": [],
+        "num_publications": 34,
+        "edge_source": "omnicorp.term_to_term"
+      },
+      {
+        "id": "98bfa494-d719-4ab5-86bf-f30346817194",
+        "source_id": "MESH:D000069470",
+        "target_id": "MONDO:0006731",
+        "type": "literature_co-occurrence",
+        "source_database": "omnicorp",
+        "publications": [],
+        "num_publications": 38,
+        "edge_source": "omnicorp.term_to_term"
+      },
+      {
+        "id": "556490ba-b8ba-4530-9d65-3662d041e434",
+        "source_id": "MESH:D008653",
+        "target_id": "MONDO:0006731",
+        "type": "literature_co-occurrence",
+        "source_database": "omnicorp",
+        "publications": [],
+        "num_publications": 4,
+        "edge_source": "omnicorp.term_to_term"
+      },
+      {
+        "id": "5e455b3f-9cb5-4bb9-bf4a-6fffa3f4007c",
+        "source_id": "MESH:D005473",
+        "target_id": "MONDO:0006731",
+        "type": "literature_co-occurrence",
+        "source_database": "omnicorp",
+        "publications": [],
+        "num_publications": 178,
+        "edge_source": "omnicorp.term_to_term"
+      },
+      {
+        "id": "0aa220af-34b7-4038-a9e6-ff5463190e07",
+        "source_id": "MESH:D013881",
+        "target_id": "MONDO:0006731",
+        "type": "literature_co-occurrence",
+        "source_database": "omnicorp",
+        "publications": [],
+        "num_publications": 57,
+        "edge_source": "omnicorp.term_to_term"
+      },
+      {
+        "id": "ce56e551-15fd-4e89-b765-70c19c04282f",
+        "source_id": "MESH:D003990",
+        "target_id": "MONDO:0006731",
+        "type": "literature_co-occurrence",
+        "source_database": "omnicorp",
+        "publications": [],
+        "num_publications": 2,
+        "edge_source": "omnicorp.term_to_term"
+      },
+      {
+        "id": "aa34fdb1-80a5-4506-9091-0f5cf8337258",
+        "source_id": "MESH:D000077582",
+        "target_id": "MONDO:0006731",
+        "type": "literature_co-occurrence",
+        "source_database": "omnicorp",
+        "publications": [],
+        "num_publications": 41,
+        "edge_source": "omnicorp.term_to_term"
+      },
+      {
+        "id": "8dec875d-2abd-4a26-a42a-bc52a3dee6fd",
+        "source_id": "MESH:D011433",
+        "target_id": "MONDO:0005466",
+        "type": "literature_co-occurrence",
+        "source_database": "omnicorp",
+        "publications": [],
+        "num_publications": 2,
+        "edge_source": "omnicorp.term_to_term"
+      },
+      {
+        "id": "bd862fa7-f909-4bb1-a48c-538c6825017f",
+        "source_id": "MESH:D000069470",
+        "target_id": "MONDO:0005466",
+        "type": "literature_co-occurrence",
+        "source_database": "omnicorp",
+        "publications": [],
+        "num_publications": 9,
+        "edge_source": "omnicorp.term_to_term"
+      },
+      {
+        "id": "1a862457-3c57-4013-a433-747657293cc2",
+        "source_id": "MESH:D011398",
+        "target_id": "MONDO:0005466",
+        "type": "literature_co-occurrence",
+        "source_database": "omnicorp",
+        "publications": [],
+        "num_publications": 2,
+        "edge_source": "omnicorp.term_to_term"
+      },
+      {
+        "id": "1be0afd9-bd9d-47d8-87f7-bf10cf75f492",
+        "source_id": "MESH:D005473",
+        "target_id": "MONDO:0005466",
+        "type": "literature_co-occurrence",
+        "source_database": "omnicorp",
+        "publications": [],
+        "num_publications": 14,
+        "edge_source": "omnicorp.term_to_term"
+      },
+      {
+        "id": "fff1059c-b59d-4cf0-a378-b71db71c01fc",
+        "source_id": "MESH:D008140",
+        "target_id": "MONDO:0005466",
+        "type": "literature_co-occurrence",
+        "source_database": "omnicorp",
+        "publications": [],
+        "num_publications": 6,
+        "edge_source": "omnicorp.term_to_term"
+      },
+      {
+        "id": "831cbe4f-53f0-4bc7-abb1-da1110ab02e2",
+        "source_id": "MESH:D011433",
+        "target_id": "MONDO:0001220",
+        "type": "literature_co-occurrence",
+        "source_database": "omnicorp",
+        "publications": [],
+        "num_publications": 6,
+        "edge_source": "omnicorp.term_to_term"
+      },
+      {
+        "id": "52b20a8d-a3e6-4a8b-b2b2-fdff59764f16",
+        "source_id": "MESH:D011433",
+        "target_id": "MONDO:0000947",
+        "type": "literature_co-occurrence",
+        "source_database": "omnicorp",
+        "publications": [],
+        "num_publications": 14,
+        "edge_source": "omnicorp.term_to_term"
+      },
+      {
+        "id": "aea64c43-0b05-43cd-bc9c-0fb6c2d29c4b",
+        "source_id": "MESH:D000069470",
+        "target_id": "MONDO:0000947",
+        "type": "literature_co-occurrence",
+        "source_database": "omnicorp",
+        "publications": [],
+        "num_publications": 14,
+        "edge_source": "omnicorp.term_to_term"
+      },
+      {
+        "id": "f8faf57b-262d-43b0-8d90-2195948db951",
+        "source_id": "MESH:D013881",
+        "target_id": "MONDO:0000947",
+        "type": "literature_co-occurrence",
+        "source_database": "omnicorp",
+        "publications": [],
+        "num_publications": 5,
+        "edge_source": "omnicorp.term_to_term"
+      },
+      {
+        "id": "ac60ff30-08d7-4903-aab8-cc625f111bd5",
+        "source_id": "MESH:D013469",
+        "target_id": "MONDO:0000947",
+        "type": "literature_co-occurrence",
+        "source_database": "omnicorp",
+        "publications": [],
+        "num_publications": 8,
+        "edge_source": "omnicorp.term_to_term"
+      },
+      {
+        "id": "0992ed71-8596-4f60-9b1e-92bff40285e6",
+        "source_id": "MESH:D005473",
+        "target_id": "MONDO:0000947",
+        "type": "literature_co-occurrence",
+        "source_database": "omnicorp",
+        "publications": [],
+        "num_publications": 79,
+        "edge_source": "omnicorp.term_to_term"
+      },
+      {
+        "id": "ca779dd6-bc10-4f95-b964-4dde6a137445",
+        "source_id": "MESH:D008140",
+        "target_id": "MONDO:0000947",
+        "type": "literature_co-occurrence",
+        "source_database": "omnicorp",
+        "publications": [],
+        "num_publications": 5,
+        "edge_source": "omnicorp.term_to_term"
+      },
+      {
+        "id": "660ff200-4ef5-48df-a6f1-4733aca70a7a",
+        "source_id": "MESH:C522667",
+        "target_id": "MONDO:0003996",
+        "type": "literature_co-occurrence",
+        "source_database": "omnicorp",
+        "publications": [],
+        "num_publications": 4,
+        "edge_source": "omnicorp.term_to_term"
+      },
+      {
+        "id": "d310e14c-16ad-4d2f-a813-090a9284ec53",
+        "source_id": "MESH:D013881",
+        "target_id": "MONDO:0003996",
+        "type": "literature_co-occurrence",
+        "source_database": "omnicorp",
+        "publications": [],
+        "num_publications": 27,
+        "edge_source": "omnicorp.term_to_term"
+      },
+      {
+        "id": "bb0db942-80ee-43e7-b8d0-f333c9d55462",
+        "source_id": "MESH:D013469",
+        "target_id": "MONDO:0003996",
+        "type": "literature_co-occurrence",
+        "source_database": "omnicorp",
+        "publications": [],
+        "num_publications": 35,
+        "edge_source": "omnicorp.term_to_term"
+      },
+      {
+        "id": "5d3f160d-93ae-4a69-b8e8-07fbe98051df",
+        "source_id": "MESH:D005473",
+        "target_id": "MONDO:0003996",
+        "type": "literature_co-occurrence",
+        "source_database": "omnicorp",
+        "publications": [],
+        "num_publications": 31,
+        "edge_source": "omnicorp.term_to_term"
+      },
+      {
+        "id": "7a775aba-517d-466c-9e2c-9a745c3df915",
+        "source_id": "MESH:D008972",
+        "target_id": "MONDO:0003996",
+        "type": "literature_co-occurrence",
+        "source_database": "omnicorp",
+        "publications": [],
+        "num_publications": 5,
+        "edge_source": "omnicorp.term_to_term"
+      },
+      {
+        "id": "a152a6f9-b8d9-4ca3-bfa0-3afda56955fe",
+        "source_id": "MESH:C007761",
+        "target_id": "MONDO:0003996",
+        "type": "literature_co-occurrence",
+        "source_database": "omnicorp",
+        "publications": [],
+        "num_publications": 3,
+        "edge_source": "omnicorp.term_to_term"
+      },
+      {
+        "id": "4785bc75-b2bc-4b56-940d-75bb932d136c",
+        "source_id": "MESH:D000077582",
+        "target_id": "MONDO:0003996",
+        "type": "literature_co-occurrence",
+        "source_database": "omnicorp",
+        "publications": [],
+        "num_publications": 16,
+        "edge_source": "omnicorp.term_to_term"
+      },
+      {
+        "id": "a959bea0-130e-4870-a33c-35589dc69120",
+        "source_id": "MESH:D000069470",
+        "target_id": "MONDO:0011728",
+        "type": "literature_co-occurrence",
+        "source_database": "omnicorp",
+        "publications": [],
+        "num_publications": 1,
+        "edge_source": "omnicorp.term_to_term"
+      },
+      {
+        "id": "7d3517f9-a270-4342-856c-1757ab9f050b",
+        "source_id": "MESH:D005473",
+        "target_id": "MONDO:0011728",
+        "type": "literature_co-occurrence",
+        "source_database": "omnicorp",
+        "publications": [],
+        "num_publications": 2,
+        "edge_source": "omnicorp.term_to_term"
+      },
+      {
+        "id": "0548276d-4ee0-4d87-8f6f-c96101c81d2e",
+        "source_id": "MESH:D013881",
+        "target_id": "MONDO:0011728",
+        "type": "literature_co-occurrence",
+        "source_database": "omnicorp",
+        "publications": [],
+        "num_publications": 1,
+        "edge_source": "omnicorp.term_to_term"
+      },
+      {
+        "id": "874d5c25-3f07-4506-9590-75bdac33dd00",
+        "source_id": "HP:0005986",
+        "target_id": "MONDO:0005090",
+        "type": "literature_co-occurrence",
+        "source_database": "omnicorp",
+        "publications": [],
+        "num_publications": 303,
+        "edge_source": "omnicorp.term_to_term"
+      },
+      {
+        "id": "e30559f0-6722-42ca-b3df-8dee74998573",
+        "source_id": "HP:0005986",
+        "target_id": "MESH:D000069470",
+        "type": "literature_co-occurrence",
+        "source_database": "omnicorp",
+        "publications": [],
+        "num_publications": 8,
+        "edge_source": "omnicorp.term_to_term"
+      },
+      {
+        "id": "792df59f-0c72-4ab1-80f3-91c6d14e1f94",
+        "source_id": "HP:0005986",
+        "target_id": "MESH:D003990",
+        "type": "literature_co-occurrence",
+        "source_database": "omnicorp",
+        "publications": [],
+        "num_publications": 1,
+        "edge_source": "omnicorp.term_to_term"
+      },
+      {
+        "id": "d8f65c5e-2690-446f-9751-742fa86ea89c",
+        "source_id": "HP:0005986",
+        "target_id": "MESH:D012436",
+        "type": "literature_co-occurrence",
+        "source_database": "omnicorp",
+        "publications": [],
+        "num_publications": 11,
+        "edge_source": "omnicorp.term_to_term"
+      },
+      {
+        "id": "b2f546bd-8ce6-4a9a-b8a4-96f11f4decc5",
+        "source_id": "HP:0005986",
+        "target_id": "MESH:D013881",
+        "type": "literature_co-occurrence",
+        "source_database": "omnicorp",
+        "publications": [],
+        "num_publications": 10,
+        "edge_source": "omnicorp.term_to_term"
+      },
+      {
+        "id": "bd755fca-bf56-4d16-abdc-734f4d464d34",
+        "source_id": "HP:0005986",
+        "target_id": "MESH:C007761",
+        "type": "literature_co-occurrence",
+        "source_database": "omnicorp",
+        "publications": [],
+        "num_publications": 1,
+        "edge_source": "omnicorp.term_to_term"
+      },
+      {
+        "id": "7ef4e325-d5b4-48d1-9094-79686fcbde54",
+        "source_id": "MESH:D013881",
+        "target_id": "MONDO:0002442",
+        "type": "literature_co-occurrence",
+        "source_database": "omnicorp",
+        "publications": [],
+        "num_publications": 24,
+        "edge_source": "omnicorp.term_to_term"
+      },
+      {
+        "id": "7efc05fc-dbf7-46cf-8877-bc6bd7b0217a",
+        "source_id": "MESH:D008653",
+        "target_id": "MONDO:0002442",
+        "type": "literature_co-occurrence",
+        "source_database": "omnicorp",
+        "publications": [],
+        "num_publications": 4,
+        "edge_source": "omnicorp.term_to_term"
+      },
+      {
+        "id": "a9012faf-fa3b-446f-a2d3-f820afeb64e5",
+        "source_id": "MESH:D005473",
+        "target_id": "MONDO:0002442",
+        "type": "literature_co-occurrence",
+        "source_database": "omnicorp",
+        "publications": [],
+        "num_publications": 20,
+        "edge_source": "omnicorp.term_to_term"
+      },
+      {
+        "id": "994eefd4-6d11-4aa8-9e5d-19929c722dc8",
+        "source_id": "MESH:D008140",
+        "target_id": "MONDO:0002442",
+        "type": "literature_co-occurrence",
+        "source_database": "omnicorp",
+        "publications": [],
+        "num_publications": 6,
+        "edge_source": "omnicorp.term_to_term"
+      },
+      {
+        "id": "d3adc1a6-5d19-4918-9871-5146ef0132e6",
+        "source_id": "MESH:D000077582",
+        "target_id": "MONDO:0002442",
+        "type": "literature_co-occurrence",
+        "source_database": "omnicorp",
+        "publications": [],
+        "num_publications": 9,
+        "edge_source": "omnicorp.term_to_term"
+      },
+      {
+        "id": "5c76198d-90e9-4ae2-a4c2-4d4aef97f9a2",
+        "source_id": "MESH:D011433",
+        "target_id": "MONDO:0001442",
+        "type": "literature_co-occurrence",
+        "source_database": "omnicorp",
+        "publications": [],
+        "num_publications": 1,
+        "edge_source": "omnicorp.term_to_term"
+      },
+      {
+        "id": "9d777176-179b-496c-8594-003803f761f2",
+        "source_id": "MESH:D000069470",
+        "target_id": "MONDO:0001442",
+        "type": "literature_co-occurrence",
+        "source_database": "omnicorp",
+        "publications": [],
+        "num_publications": 26,
+        "edge_source": "omnicorp.term_to_term"
+      },
+      {
+        "id": "d88cc98f-fcd7-41a4-9542-b77f7bc0cc9b",
+        "source_id": "MESH:C515050",
+        "target_id": "MONDO:0001442",
+        "type": "literature_co-occurrence",
+        "source_database": "omnicorp",
+        "publications": [],
+        "num_publications": 1,
+        "edge_source": "omnicorp.term_to_term"
+      },
+      {
+        "id": "f91db030-24bb-4579-85e9-ede16ee1c071",
+        "source_id": "MESH:D005473",
+        "target_id": "MONDO:0001442",
+        "type": "literature_co-occurrence",
+        "source_database": "omnicorp",
+        "publications": [],
+        "num_publications": 50,
+        "edge_source": "omnicorp.term_to_term"
+      },
+      {
+        "id": "1bb70847-c052-482e-9b9b-7eaffd9b3736",
+        "source_id": "MONDO:0001484",
+        "target_id": "MONDO:0005090",
+        "type": "literature_co-occurrence",
+        "source_database": "omnicorp",
+        "publications": [],
+        "num_publications": 7,
+        "edge_source": "omnicorp.term_to_term"
+      },
+      {
+        "id": "823e078a-05fa-4ebd-b9ec-352e1b063e55",
+        "source_id": "MESH:D013469",
+        "target_id": "MONDO:0001484",
+        "type": "literature_co-occurrence",
+        "source_database": "omnicorp",
+        "publications": [],
+        "num_publications": 31,
+        "edge_source": "omnicorp.term_to_term"
+      },
+      {
+        "id": "398a62b3-2808-4ebf-ba56-1a3b2e753f10",
+        "source_id": "MESH:D013881",
+        "target_id": "MONDO:0001484",
+        "type": "literature_co-occurrence",
+        "source_database": "omnicorp",
+        "publications": [],
+        "num_publications": 29,
+        "edge_source": "omnicorp.term_to_term"
+      },
+      {
+        "id": "99f17418-53d2-4eaa-8813-8c929d7b5b5b",
+        "source_id": "MESH:D000077582",
+        "target_id": "MONDO:0001484",
+        "type": "literature_co-occurrence",
+        "source_database": "omnicorp",
+        "publications": [],
+        "num_publications": 27,
+        "edge_source": "omnicorp.term_to_term"
+      },
+      {
+        "id": "a92df2d1-ba65-4a63-bbb5-b621afb70d34",
+        "source_id": "MONDO:0002025",
+        "target_id": "MONDO:0005090",
+        "type": "literature_co-occurrence",
+        "source_database": "omnicorp",
+        "publications": [],
+        "num_publications": 2,
+        "edge_source": "omnicorp.term_to_term"
+      },
+      {
+        "id": "a93f51b2-2c79-450a-bed5-44a9e97de625",
+        "source_id": "MESH:D014282",
+        "target_id": "MONDO:0002025",
+        "type": "literature_co-occurrence",
+        "source_database": "omnicorp",
+        "publications": [],
+        "num_publications": 26,
+        "edge_source": "omnicorp.term_to_term"
+      },
+      {
+        "id": "d137ff43-f140-46c8-80df-5de110061c05",
+        "source_id": "MESH:D000069470",
+        "target_id": "MONDO:0002025",
+        "type": "literature_co-occurrence",
+        "source_database": "omnicorp",
+        "publications": [],
+        "num_publications": 130,
+        "edge_source": "omnicorp.term_to_term"
+      },
+      {
+        "id": "1fdf7e1d-a3c0-4d99-9117-f0444c1512bb",
+        "source_id": "MESH:D013469",
+        "target_id": "MONDO:0002025",
+        "type": "literature_co-occurrence",
+        "source_database": "omnicorp",
+        "publications": [],
+        "num_publications": 75,
+        "edge_source": "omnicorp.term_to_term"
+      },
+      {
+        "id": "1bad7a2b-9176-4c4b-83c8-35684f597c4d",
+        "source_id": "MESH:D013881",
+        "target_id": "MONDO:0002025",
+        "type": "literature_co-occurrence",
+        "source_database": "omnicorp",
+        "publications": [],
+        "num_publications": 233,
+        "edge_source": "omnicorp.term_to_term"
+      },
+      {
+        "id": "28983c69-3f4a-4459-8705-d04e36a3705f",
+        "source_id": "MESH:D008972",
+        "target_id": "MONDO:0002025",
+        "type": "literature_co-occurrence",
+        "source_database": "omnicorp",
+        "publications": [],
+        "num_publications": 7,
+        "edge_source": "omnicorp.term_to_term"
+      },
+      {
+        "id": "85081a49-7155-4b80-beb6-8c1eceae2977",
+        "source_id": "MESH:D000077582",
+        "target_id": "MONDO:0002025",
+        "type": "literature_co-occurrence",
+        "source_database": "omnicorp",
+        "publications": [],
+        "num_publications": 32,
+        "edge_source": "omnicorp.term_to_term"
+      },
+      {
+        "id": "e532e180-58d8-4a64-9683-9aab9c897b43",
+        "source_id": "MESH:D005473",
+        "target_id": "MONDO:0016058",
+        "type": "literature_co-occurrence",
+        "source_database": "omnicorp",
+        "publications": [],
+        "num_publications": 1,
+        "edge_source": "omnicorp.term_to_term"
+      },
+      {
+        "id": "18c4cb08-d6db-4c18-b788-545a3b8ced36",
+        "source_id": "MESH:D011398",
+        "target_id": "MONDO:0005478",
+        "type": "literature_co-occurrence",
+        "source_database": "omnicorp",
+        "publications": [],
+        "num_publications": 4,
+        "edge_source": "omnicorp.term_to_term"
+      },
+      {
+        "id": "48eab723-6fa1-4a75-8aa2-77baf3f03bed",
+        "source_id": "MESH:D008653",
+        "target_id": "MONDO:0005478",
+        "type": "literature_co-occurrence",
+        "source_database": "omnicorp",
+        "publications": [],
+        "num_publications": 1,
+        "edge_source": "omnicorp.term_to_term"
+      },
+      {
+        "id": "cb718e50-ab7c-4853-b4a6-79050c88a457",
+        "source_id": "MESH:D013469",
+        "target_id": "MONDO:0005478",
+        "type": "literature_co-occurrence",
+        "source_database": "omnicorp",
+        "publications": [],
+        "num_publications": 18,
+        "edge_source": "omnicorp.term_to_term"
+      },
+      {
+        "id": "065e509d-c64b-4d56-93e2-c8bb303d19b2",
+        "source_id": "MESH:D005473",
+        "target_id": "MONDO:0005478",
+        "type": "literature_co-occurrence",
+        "source_database": "omnicorp",
+        "publications": [],
+        "num_publications": 11,
+        "edge_source": "omnicorp.term_to_term"
+      },
+      {
+        "id": "8f8613a5-93cb-44d2-a181-b09006a3d87f",
+        "source_id": "MESH:D013881",
+        "target_id": "MONDO:0005478",
+        "type": "literature_co-occurrence",
+        "source_database": "omnicorp",
+        "publications": [],
+        "num_publications": 30,
+        "edge_source": "omnicorp.term_to_term"
+      },
+      {
+        "id": "12a049b0-1c10-493c-9ef6-2143711313c1",
+        "source_id": "MESH:D014282",
+        "target_id": "MONDO:0005478",
+        "type": "literature_co-occurrence",
+        "source_database": "omnicorp",
+        "publications": [],
+        "num_publications": 1,
+        "edge_source": "omnicorp.term_to_term"
+      },
+      {
+        "id": "e10558a3-363d-4af7-b179-e213d3f14b58",
+        "source_id": "MESH:D000077582",
+        "target_id": "MONDO:0005478",
+        "type": "literature_co-occurrence",
+        "source_database": "omnicorp",
+        "publications": [],
+        "num_publications": 11,
+        "edge_source": "omnicorp.term_to_term"
+      },
+      {
+        "id": "436a295e-fa35-45af-b2f3-eda197095746",
+        "source_id": "MESH:D011433",
+        "target_id": "MONDO:0045057",
+        "type": "literature_co-occurrence",
+        "source_database": "omnicorp",
+        "publications": [],
+        "num_publications": 38,
+        "edge_source": "omnicorp.term_to_term"
+      },
+      {
+        "id": "794682a0-c642-4886-8e5b-3cac630a099a",
+        "source_id": "MESH:D000069470",
+        "target_id": "MONDO:0045057",
+        "type": "literature_co-occurrence",
+        "source_database": "omnicorp",
+        "publications": [],
+        "num_publications": 14,
+        "edge_source": "omnicorp.term_to_term"
+      },
+      {
+        "id": "807eb09a-8ec6-4a63-bc52-1084f10a46f2",
+        "source_id": "MESH:D013881",
+        "target_id": "MONDO:0045057",
+        "type": "literature_co-occurrence",
+        "source_database": "omnicorp",
+        "publications": [],
+        "num_publications": 29,
+        "edge_source": "omnicorp.term_to_term"
+      },
+      {
+        "id": "db7345bd-6363-4caf-9a59-5435850372b0",
+        "source_id": "MESH:D001712",
+        "target_id": "MONDO:0045057",
+        "type": "literature_co-occurrence",
+        "source_database": "omnicorp",
+        "publications": [],
+        "num_publications": 9,
+        "edge_source": "omnicorp.term_to_term"
+      },
+      {
+        "id": "03cf8183-fe7a-428d-80db-61b72c6c8ba2",
+        "source_id": "MESH:D011398",
+        "target_id": "MONDO:0045057",
+        "type": "literature_co-occurrence",
+        "source_database": "omnicorp",
+        "publications": [],
+        "num_publications": 18,
+        "edge_source": "omnicorp.term_to_term"
+      },
+      {
+        "id": "8f6819a0-41ce-4f8c-b68d-e614b08f9aae",
+        "source_id": "MESH:D005473",
+        "target_id": "MONDO:0045057",
+        "type": "literature_co-occurrence",
+        "source_database": "omnicorp",
+        "publications": [],
+        "num_publications": 38,
+        "edge_source": "omnicorp.term_to_term"
+      },
+      {
+        "id": "97b0288b-1dc2-4b19-9489-dc26ad268754",
+        "source_id": "MESH:D008140",
+        "target_id": "MONDO:0045057",
+        "type": "literature_co-occurrence",
+        "source_database": "omnicorp",
+        "publications": [],
+        "num_publications": 115,
+        "edge_source": "omnicorp.term_to_term"
+      },
+      {
+        "id": "de80bacf-a3ab-4879-896c-aa457b083381",
+        "source_id": "MESH:D014282",
+        "target_id": "MONDO:0045057",
+        "type": "literature_co-occurrence",
+        "source_database": "omnicorp",
+        "publications": [],
+        "num_publications": 15,
+        "edge_source": "omnicorp.term_to_term"
+      },
+      {
+        "id": "dd2170b3-8ffc-463a-a5a4-55be6a0950e0",
+        "source_id": "MESH:D000069470",
+        "target_id": "MONDO:0006966",
+        "type": "literature_co-occurrence",
+        "source_database": "omnicorp",
+        "publications": [],
+        "num_publications": 3,
+        "edge_source": "omnicorp.term_to_term"
+      },
+      {
+        "id": "c94ca951-813a-443f-bfb7-39d6a3cf11b5",
+        "source_id": "MESH:D013469",
+        "target_id": "MONDO:0006966",
+        "type": "literature_co-occurrence",
+        "source_database": "omnicorp",
+        "publications": [],
+        "num_publications": 30,
+        "edge_source": "omnicorp.term_to_term"
+      },
+      {
+        "id": "b665b3fc-0558-44ee-92ba-2b318731875c",
+        "source_id": "MESH:D005473",
+        "target_id": "MONDO:0006966",
+        "type": "literature_co-occurrence",
+        "source_database": "omnicorp",
+        "publications": [],
+        "num_publications": 13,
+        "edge_source": "omnicorp.term_to_term"
+      },
+      {
+        "id": "ca5e74d3-3261-4261-b0a8-7016ad250f61",
+        "source_id": "MESH:D013881",
+        "target_id": "MONDO:0006966",
+        "type": "literature_co-occurrence",
+        "source_database": "omnicorp",
+        "publications": [],
+        "num_publications": 22,
+        "edge_source": "omnicorp.term_to_term"
+      },
+      {
+        "id": "acdb2db7-846e-4382-a828-14f052c9c933",
+        "source_id": "MESH:C007761",
+        "target_id": "MONDO:0006966",
+        "type": "literature_co-occurrence",
+        "source_database": "omnicorp",
+        "publications": [],
+        "num_publications": 2,
+        "edge_source": "omnicorp.term_to_term"
+      },
+      {
+        "id": "4f30bd51-ec21-4376-91d8-5475995b6eb0",
+        "source_id": "MESH:D000077582",
+        "target_id": "MONDO:0006966",
+        "type": "literature_co-occurrence",
+        "source_database": "omnicorp",
+        "publications": [],
+        "num_publications": 1,
+        "edge_source": "omnicorp.term_to_term"
+      },
+      {
+        "id": "12806415-9f97-4d34-9857-72fb6885dce8",
+        "source_id": "MESH:D013469",
+        "target_id": "MONDO:0005146",
+        "type": "literature_co-occurrence",
+        "source_database": "omnicorp",
+        "publications": [],
+        "num_publications": 6,
+        "edge_source": "omnicorp.term_to_term"
+      },
+      {
+        "id": "b220423f-1e58-4d5a-9250-9cd99b300ce4",
+        "source_id": "MESH:D005473",
+        "target_id": "MONDO:0005146",
+        "type": "literature_co-occurrence",
+        "source_database": "omnicorp",
+        "publications": [],
+        "num_publications": 76,
+        "edge_source": "omnicorp.term_to_term"
+      },
+      {
+        "id": "d02bfccf-a7a6-4749-bf23-843d4b36ecbd",
+        "source_id": "MESH:D008140",
+        "target_id": "MONDO:0005146",
+        "type": "literature_co-occurrence",
+        "source_database": "omnicorp",
+        "publications": [],
+        "num_publications": 5,
+        "edge_source": "omnicorp.term_to_term"
+      },
+      {
+        "id": "da330570-1c52-4a70-87cd-a53e55575437",
+        "source_id": "MESH:D000069470",
+        "target_id": "MONDO:0005146",
+        "type": "literature_co-occurrence",
+        "source_database": "omnicorp",
+        "publications": [],
+        "num_publications": 34,
+        "edge_source": "omnicorp.term_to_term"
+      },
+      {
+        "id": "4d2d0f2c-559f-43a5-8b29-f0f62a9287f2",
+        "source_id": "MESH:D013881",
+        "target_id": "MONDO:0005146",
+        "type": "literature_co-occurrence",
+        "source_database": "omnicorp",
+        "publications": [],
+        "num_publications": 1,
+        "edge_source": "omnicorp.term_to_term"
+      },
+      {
+        "id": "14b1fb28-7666-482d-919f-7c864cb38663",
+        "source_id": "HP:0001662",
+        "target_id": "MONDO:0005090",
+        "type": "literature_co-occurrence",
+        "source_database": "omnicorp",
+        "publications": [],
+        "num_publications": 84,
+        "edge_source": "omnicorp.term_to_term"
+      },
+      {
+        "id": "47a22d2a-f765-4fdf-bf31-dd3ce6df5f8a",
+        "source_id": "HP:0001662",
+        "target_id": "MESH:D001712",
+        "type": "literature_co-occurrence",
+        "source_database": "omnicorp",
+        "publications": [],
+        "num_publications": 1,
+        "edge_source": "omnicorp.term_to_term"
+      },
+      {
+        "id": "c9ea8250-99c6-4b4e-8483-3ef348f68377",
+        "source_id": "HP:0001662",
+        "target_id": "MESH:D011398",
+        "type": "literature_co-occurrence",
+        "source_database": "omnicorp",
+        "publications": [],
+        "num_publications": 10,
+        "edge_source": "omnicorp.term_to_term"
+      },
+      {
+        "id": "8abb4c26-cb25-4a1a-9951-0d10ef0ad43a",
+        "source_id": "HP:0001662",
+        "target_id": "MESH:D012906",
+        "type": "literature_co-occurrence",
+        "source_database": "omnicorp",
+        "publications": [],
+        "num_publications": 20,
+        "edge_source": "omnicorp.term_to_term"
+      },
+      {
+        "id": "2e24012f-5e90-46df-855f-cc81fd6f3e0e",
+        "source_id": "HP:0001662",
+        "target_id": "MESH:D008140",
+        "type": "literature_co-occurrence",
+        "source_database": "omnicorp",
+        "publications": [],
+        "num_publications": 10,
+        "edge_source": "omnicorp.term_to_term"
+      },
+      {
+        "id": "0e24deb4-29dd-40d7-a3ea-70a8af00e515",
+        "source_id": "HP:0001662",
+        "target_id": "MESH:D014282",
+        "type": "literature_co-occurrence",
+        "source_database": "omnicorp",
+        "publications": [],
+        "num_publications": 3,
+        "edge_source": "omnicorp.term_to_term"
+      },
+      {
+        "id": "976a5e21-8c64-4467-bf4e-9aef2544eca9",
+        "source_id": "HP:0001662",
+        "target_id": "MESH:D000077582",
+        "type": "literature_co-occurrence",
+        "source_database": "omnicorp",
+        "publications": [],
+        "num_publications": 5,
+        "edge_source": "omnicorp.term_to_term"
+      },
+      {
+        "id": "e7bda5c2-0470-4b09-a37d-780401390225",
+        "source_id": "MESH:D008140",
+        "target_id": "MONDO:0005640",
+        "type": "literature_co-occurrence",
+        "source_database": "omnicorp",
+        "publications": [],
+        "num_publications": 2,
+        "edge_source": "omnicorp.term_to_term"
+      },
+      {
+        "id": "c0de62aa-d8fa-4443-972b-fca3b3a6d4b4",
+        "source_id": "MONDO:0002265",
+        "target_id": "MONDO:0005090",
+        "type": "literature_co-occurrence",
+        "source_database": "omnicorp",
+        "publications": [],
+        "num_publications": 262,
+        "edge_source": "omnicorp.term_to_term"
+      },
+      {
+        "id": "1c97380a-bec6-47a3-97b8-358b51e5a3df",
+        "source_id": "MESH:C030265",
+        "target_id": "MONDO:0002265",
+        "type": "literature_co-occurrence",
+        "source_database": "omnicorp",
+        "publications": [],
+        "num_publications": 12,
+        "edge_source": "omnicorp.term_to_term"
+      },
+      {
+        "id": "cb85b966-ded4-43fb-9649-c70f4ae409ad",
+        "source_id": "MESH:D013469",
+        "target_id": "MONDO:0002265",
+        "type": "literature_co-occurrence",
+        "source_database": "omnicorp",
+        "publications": [],
+        "num_publications": 117,
+        "edge_source": "omnicorp.term_to_term"
+      },
+      {
+        "id": "774a1f68-1434-466f-915d-23b9b0cf85c6",
+        "source_id": "MESH:D000069470",
+        "target_id": "MONDO:0002265",
+        "type": "literature_co-occurrence",
+        "source_database": "omnicorp",
+        "publications": [],
+        "num_publications": 4,
+        "edge_source": "omnicorp.term_to_term"
+      },
+      {
+        "id": "e22b1f7f-1794-41d6-9644-2a3c6cde6429",
+        "source_id": "MONDO:0005090",
+        "target_id": "MONDO:0005395",
+        "type": "literature_co-occurrence",
+        "source_database": "omnicorp",
+        "publications": [],
+        "num_publications": 121,
+        "edge_source": "omnicorp.term_to_term"
+      },
+      {
+        "id": "0728362b-109f-436d-9286-79f7a58524de",
+        "source_id": "MESH:D011433",
+        "target_id": "MONDO:0005395",
+        "type": "literature_co-occurrence",
+        "source_database": "omnicorp",
+        "publications": [],
+        "num_publications": 45,
+        "edge_source": "omnicorp.term_to_term"
+      },
+      {
+        "id": "4b643bee-b377-4416-9d52-8eccd5d7ff85",
+        "source_id": "MESH:D000069470",
+        "target_id": "MONDO:0005395",
+        "type": "literature_co-occurrence",
+        "source_database": "omnicorp",
+        "publications": [],
+        "num_publications": 5,
+        "edge_source": "omnicorp.term_to_term"
+      },
+      {
+        "id": "1320bd09-009d-4746-8b0f-e8897a765175",
+        "source_id": "MESH:D013881",
+        "target_id": "MONDO:0005395",
+        "type": "literature_co-occurrence",
+        "source_database": "omnicorp",
+        "publications": [],
+        "num_publications": 36,
+        "edge_source": "omnicorp.term_to_term"
+      },
+      {
+        "id": "7ed06cf7-f058-4b43-91dd-7c951dfdd7ac",
+        "source_id": "MESH:D013469",
+        "target_id": "MONDO:0005395",
+        "type": "literature_co-occurrence",
+        "source_database": "omnicorp",
+        "publications": [],
+        "num_publications": 29,
+        "edge_source": "omnicorp.term_to_term"
+      },
+      {
+        "id": "7115a8d7-6d73-4b8f-9604-5a467ebf0185",
+        "source_id": "MESH:D005473",
+        "target_id": "MONDO:0005395",
+        "type": "literature_co-occurrence",
+        "source_database": "omnicorp",
+        "publications": [],
+        "num_publications": 17,
+        "edge_source": "omnicorp.term_to_term"
+      },
+      {
+        "id": "37e2b4de-103f-4f4b-9b33-2ced9152c7db",
+        "source_id": "MESH:D008140",
+        "target_id": "MONDO:0005395",
+        "type": "literature_co-occurrence",
+        "source_database": "omnicorp",
+        "publications": [],
+        "num_publications": 10,
+        "edge_source": "omnicorp.term_to_term"
+      },
+      {
+        "id": "7c18b605-551f-4671-b5d2-fa84bce2c393",
+        "source_id": "MESH:C007761",
+        "target_id": "MONDO:0005395",
+        "type": "literature_co-occurrence",
+        "source_database": "omnicorp",
+        "publications": [],
+        "num_publications": 3,
+        "edge_source": "omnicorp.term_to_term"
+      },
+      {
+        "id": "a0fa83d4-f400-429c-ab03-7b052c16d799",
+        "source_id": "MESH:D011433",
+        "target_id": "MONDO:0005359",
+        "type": "literature_co-occurrence",
+        "source_database": "omnicorp",
+        "publications": [],
+        "num_publications": 24,
+        "edge_source": "omnicorp.term_to_term"
+      },
+      {
+        "id": "7af1a78c-6e0a-4d3c-a47b-777f82f42aa3",
+        "source_id": "MESH:D000069470",
+        "target_id": "MONDO:0005359",
+        "type": "literature_co-occurrence",
+        "source_database": "omnicorp",
+        "publications": [],
+        "num_publications": 12,
+        "edge_source": "omnicorp.term_to_term"
+      },
+      {
+        "id": "4d39039f-25f4-476b-bc8f-5ab729d793b8",
+        "source_id": "MESH:D013881",
+        "target_id": "MONDO:0005359",
+        "type": "literature_co-occurrence",
+        "source_database": "omnicorp",
+        "publications": [],
+        "num_publications": 12,
+        "edge_source": "omnicorp.term_to_term"
+      },
+      {
+        "id": "a182fdde-070d-4568-b1b8-5b2545a08c80",
+        "source_id": "MESH:D011398",
+        "target_id": "MONDO:0005359",
+        "type": "literature_co-occurrence",
+        "source_database": "omnicorp",
+        "publications": [],
+        "num_publications": 28,
+        "edge_source": "omnicorp.term_to_term"
+      },
+      {
+        "id": "e842b819-fc45-498f-9033-f5d03959bc1f",
+        "source_id": "MESH:D013469",
+        "target_id": "MONDO:0005359",
+        "type": "literature_co-occurrence",
+        "source_database": "omnicorp",
+        "publications": [],
+        "num_publications": 4,
+        "edge_source": "omnicorp.term_to_term"
+      },
+      {
+        "id": "ddad3e96-adee-4ee2-8512-bce07b43a764",
+        "source_id": "MESH:D012906",
+        "target_id": "MONDO:0005359",
+        "type": "literature_co-occurrence",
+        "source_database": "omnicorp",
+        "publications": [],
+        "num_publications": 4,
+        "edge_source": "omnicorp.term_to_term"
+      },
+      {
+        "id": "1aa9e3dc-c871-495f-82b6-5029c4eb6d2a",
+        "source_id": "MESH:D005473",
+        "target_id": "MONDO:0005359",
+        "type": "literature_co-occurrence",
+        "source_database": "omnicorp",
+        "publications": [],
+        "num_publications": 22,
+        "edge_source": "omnicorp.term_to_term"
+      },
+      {
+        "id": "4a4e7a67-6bc7-4049-9248-61114a1b0f73",
+        "source_id": "MONDO:0002050",
+        "target_id": "MONDO:0005090",
+        "type": "literature_co-occurrence",
+        "source_database": "omnicorp",
+        "publications": [],
+        "num_publications": 2089,
+        "edge_source": "omnicorp.term_to_term"
+      },
+      {
+        "id": "21adc088-adea-41e2-a459-451ba77164d6",
+        "source_id": "MESH:D001712",
+        "target_id": "MONDO:0002050",
+        "type": "literature_co-occurrence",
+        "source_database": "omnicorp",
+        "publications": [],
+        "num_publications": 35,
+        "edge_source": "omnicorp.term_to_term"
+      },
+      {
+        "id": "f06f2ec5-551e-4933-b268-dc4f87a5f354",
+        "source_id": "MESH:D012436",
+        "target_id": "MONDO:0002050",
+        "type": "literature_co-occurrence",
+        "source_database": "omnicorp",
+        "publications": [],
+        "num_publications": 211,
+        "edge_source": "omnicorp.term_to_term"
+      },
+      {
+        "id": "9f36e401-b0e9-43ce-8063-fd7fb87dc31f",
+        "source_id": "MESH:D013469",
+        "target_id": "MONDO:0002050",
+        "type": "literature_co-occurrence",
+        "source_database": "omnicorp",
+        "publications": [],
+        "num_publications": 261,
+        "edge_source": "omnicorp.term_to_term"
+      },
+      {
+        "id": "b1e24050-81ed-4a69-aba3-9392ea6ee41c",
+        "source_id": "MESH:D013881",
+        "target_id": "MONDO:0002050",
+        "type": "literature_co-occurrence",
+        "source_database": "omnicorp",
+        "publications": [],
+        "num_publications": 175,
+        "edge_source": "omnicorp.term_to_term"
+      },
+      {
+        "id": "7a41702d-f102-41a5-b740-1189b61a4d24",
+        "source_id": "MESH:C007761",
+        "target_id": "MONDO:0002050",
+        "type": "literature_co-occurrence",
+        "source_database": "omnicorp",
+        "publications": [],
+        "num_publications": 14,
+        "edge_source": "omnicorp.term_to_term"
+      },
+      {
+        "id": "bdc477f0-0952-406f-b862-407b5010bc49",
+        "source_id": "MESH:D000077582",
+        "target_id": "MONDO:0002050",
+        "type": "literature_co-occurrence",
+        "source_database": "omnicorp",
+        "publications": [],
+        "num_publications": 63,
+        "edge_source": "omnicorp.term_to_term"
+      },
+      {
+        "id": "2f09b56b-f7f5-40d5-877a-100ce84171ea",
+        "source_id": "MONDO:0005090",
+        "target_id": "MONDO:0005485",
+        "type": "literature_co-occurrence",
+        "source_database": "omnicorp",
+        "publications": [],
+        "num_publications": 4,
+        "edge_source": "omnicorp.term_to_term"
+      },
+      {
+        "id": "00228345-80b8-4a70-b44a-be520203b163",
+        "source_id": "MESH:D013469",
+        "target_id": "MONDO:0005485",
+        "type": "literature_co-occurrence",
+        "source_database": "omnicorp",
+        "publications": [],
+        "num_publications": 163,
+        "edge_source": "omnicorp.term_to_term"
+      },
+      {
+        "id": "c371b593-6348-4ea9-8b6a-aedc77900db8",
+        "source_id": "MESH:D008972",
+        "target_id": "MONDO:0005485",
+        "type": "literature_co-occurrence",
+        "source_database": "omnicorp",
+        "publications": [],
+        "num_publications": 24,
+        "edge_source": "omnicorp.term_to_term"
+      },
+      {
+        "id": "c74eee45-07ae-4c2c-88fc-f842e6920eed",
+        "source_id": "MESH:D008140",
+        "target_id": "MONDO:0005485",
+        "type": "literature_co-occurrence",
+        "source_database": "omnicorp",
+        "publications": [],
+        "num_publications": 117,
+        "edge_source": "omnicorp.term_to_term"
+      },
+      {
+        "id": "af45c835-6be1-4845-bda8-35dd6018cb79",
+        "source_id": "MESH:C007761",
+        "target_id": "MONDO:0005485",
+        "type": "literature_co-occurrence",
+        "source_database": "omnicorp",
+        "publications": [],
+        "num_publications": 11,
+        "edge_source": "omnicorp.term_to_term"
+      },
+      {
+        "id": "52efd8ba-5bd7-467f-92f9-7f879b4460c8",
+        "source_id": "MESH:D013881",
+        "target_id": "MONDO:0005485",
+        "type": "literature_co-occurrence",
+        "source_database": "omnicorp",
+        "publications": [],
+        "num_publications": 205,
+        "edge_source": "omnicorp.term_to_term"
+      },
+      {
+        "id": "81a5c970-b39b-418e-9457-73a6b8114c68",
+        "source_id": "MESH:D000077582",
+        "target_id": "MONDO:0005485",
+        "type": "literature_co-occurrence",
+        "source_database": "omnicorp",
+        "publications": [],
+        "num_publications": 106,
+        "edge_source": "omnicorp.term_to_term"
+      },
+      {
+        "id": "a756a2b3-8bfc-4d24-82b0-36c506bb13ba",
+        "source_id": "MESH:D001712",
+        "target_id": "MONDO:0005485",
+        "type": "literature_co-occurrence",
+        "source_database": "omnicorp",
+        "publications": [],
+        "num_publications": 32,
+        "edge_source": "omnicorp.term_to_term"
+      }
+    ]
+  },
+  "results": [
+    {
+      "node_bindings": [
+        {
+          "qg_id": "a",
+          "kg_id": [
+            "MONDO:0005090"
+          ]
+        },
+        {
+          "qg_id": "b",
+          "kg_id": [
+            "CHEBI:8707",
+            "MESH:D011433",
+            "CHEBI:7735",
+            "CHEBI:64050",
+            "MESH:D013469",
+            "CHEMBL.COMPOUND:CHEMBL218166",
+            "MESH:D008140",
+            "CHEBI:70735",
+            "MESH:D003990",
+            "CHEBI:31981",
+            "MESH:D011352",
+            "MESH:D000069470",
+            "CHEBI:5613",
+            "CHEBI:65173",
+            "MESH:D001712",
+            "MESH:D012436",
+            "CHEBI:3766",
+            "MESH:D008972",
+            "MESH:C030265",
+            "MESH:C522667",
+            "CHEBI:34605",
+            "CHEBI:31236",
+            "CHEBI:135778",
+            "CHEBI:10119",
+            "MESH:D011398",
+            "MESH:D008653",
+            "MESH:D012906",
+            "MESH:D005473",
+            "MESH:C100234",
+            "CHEMBL.COMPOUND:CHEMBL2105481",
+            "MESH:D013881",
+            "MESH:C060342",
+            "CHEBI:92293",
+            "CHEMBL.COMPOUND:CHEMBL2106135",
+            "MESH:C515050",
+            "MESH:D014282",
+            "MESH:C007761",
+            "MESH:D000077582",
+            "CHEBI:8871"
+          ],
+          "enriched_nodes": [
+            "MONDO:0005090"
+          ],
+          "p_value": 3.1381498716889738e-111,
+          "coalescence_method": "graph_enrichment"
+        },
+        {
+          "qg_id": "extra_qn_0",
+          "kg_id": [
+            "MONDO:0005090"
+          ]
+        }
+      ],
+      "edge_bindings": [
+        {
+          "qg_id": "ab",
+          "kg_id": "d14eb3961c1f7388e1d825087793b09c",
+          "weight": 0.9952594092303608
+        },
+        {
+          "qg_id": "ab",
+          "kg_id": "d614c7ce9753c9c96776b0b8c0496b90",
+          "weight": 0.4999999999999998
+        },
+        {
+          "qg_id": "ab",
+          "kg_id": "4a11a33f29fdbe47355079b7f43d97d0",
+          "weight": 0.6772190444071822
+        },
+        {
+          "qg_id": "ab",
+          "kg_id": "a6dd784998583735c9cdcae7246c05f3",
+          "weight": 0.4999999999999998
+        },
+        {
+          "qg_id": "ab",
+          "kg_id": "ec69907b8aa355c68a3028d491774cb8",
+          "weight": 0.4999999999999998
+        },
+        {
+          "qg_id": "ab",
+          "kg_id": "62769563de9abea21d061f71c8e1f092",
+          "weight": 0.4999999999999998
+        },
+        {
+          "qg_id": "ab",
+          "kg_id": "25ca4674bccf3d3623ec99ddd401fef8",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "ab",
+          "kg_id": "477e260e9fd1ccd91159dbe57337c22e",
+          "weight": 0.4999999999999998
+        },
+        {
+          "qg_id": "ab",
+          "kg_id": "ead0c39f0b111e2554d42e09c6639da7",
+          "weight": 0.6772190444071822
+        },
+        {
+          "qg_id": "ab",
+          "kg_id": "5f9d7ec7475fcd03c7d0349c3d43ffd7",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "ab",
+          "kg_id": "b81fdf71694595916d701accb5b538ac",
+          "weight": 0.7999999999999998
+        },
+        {
+          "qg_id": "ab",
+          "kg_id": "0f708fa3e227b1fc99acf54b86ab0067",
+          "weight": 0.4999999999999998
+        },
+        {
+          "qg_id": "ab",
+          "kg_id": "29805b4c97964fbcbc034e51592e1025",
+          "weight": 0.4999999999999998
+        },
+        {
+          "qg_id": "ab",
+          "kg_id": "5c92c1173e1b6b916355bc842d5c39e4",
+          "weight": 0.6772190444071822
+        },
+        {
+          "qg_id": "ab",
+          "kg_id": "4dcb2c732371e398b09ec26055f6359b",
+          "weight": 0.4999999999999998
+        },
+        {
+          "qg_id": "ab",
+          "kg_id": "48bfeb51ce3308d17910fcf7e55fe738",
+          "weight": 0.4999999999999998
+        },
+        {
+          "qg_id": "ab",
+          "kg_id": "45bb9997c8ac47225836c8e74cf91b5a",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "ab",
+          "kg_id": "498c4c27bfd963f51fa822ad7f5a43cc",
+          "weight": 0.4999999999999998
+        },
+        {
+          "qg_id": "ab",
+          "kg_id": "14403bd92938ce4daec86a4771bf62e5",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "ab",
+          "kg_id": "1f6d1af9c9790d9e764acbcefa529560",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "ab",
+          "kg_id": "b10e8f04da87590a3f4594b55cb5f622",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "ab",
+          "kg_id": "b350a7cdeb917e5427a848255024e654",
+          "weight": 0.4999999999999998
+        },
+        {
+          "qg_id": "ab",
+          "kg_id": "d30fdf6603478e158753fa54579c3bc8",
+          "weight": 0.4999999999999998
+        },
+        {
+          "qg_id": "ab",
+          "kg_id": "4c31cfcb4fcca8119bacadf5ff9c7c3f",
+          "weight": 0.4999999999999998
+        },
+        {
+          "qg_id": "ab",
+          "kg_id": "27e2d9c80f455b07035189d2d2185cc7",
+          "weight": 0.4999999999999998
+        },
+        {
+          "qg_id": "ab",
+          "kg_id": "444737174a86b6215191c9ac6115486b",
+          "weight": 0.4999999999999998
+        },
+        {
+          "qg_id": "ab",
+          "kg_id": "f07c7b7ecfe8842148bd274046d16b91",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "ab",
+          "kg_id": "3f2dce542d551845ef737b2104a0a382",
+          "weight": 0.4999999999999998
+        },
+        {
+          "qg_id": "ab",
+          "kg_id": "926bbe3b8fa81d53f421602d766bccde",
+          "weight": 0.4999999999999998
+        },
+        {
+          "qg_id": "ab",
+          "kg_id": "43821d8754c5fd847b24ae5bff93cf0b",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "ab",
+          "kg_id": "faf12afc64a27e030125dd3011fcff06",
+          "weight": 0.6772190444071822
+        },
+        {
+          "qg_id": "ab",
+          "kg_id": "7e2638ffd0752352debdae9307986f8d",
+          "weight": 0.4999999999999998
+        },
+        {
+          "qg_id": "ab",
+          "kg_id": "46d04f20397875b7376435c704c3bd02",
+          "weight": 0.4999999999999998
+        },
+        {
+          "qg_id": "ab",
+          "kg_id": "f35fb52da54f92f60696a99e84bfa51a",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "ab",
+          "kg_id": "ecd1e07e353f9416c93c3e9b5e098d77",
+          "weight": 0.4999999999999998
+        },
+        {
+          "qg_id": "ab",
+          "kg_id": "9b613f3b2cf64f7a0b7ca99f716d67d6",
+          "weight": 0.9996952148735141
+        },
+        {
+          "qg_id": "ab",
+          "kg_id": "8efc24e375e9f21c0dcabd50d9df36e2",
+          "weight": 0.4999999999999998
+        },
+        {
+          "qg_id": "ab",
+          "kg_id": "b59a6c9652482f7a0b9f83afc9ae4146",
+          "weight": 0.4999999999999998
+        },
+        {
+          "qg_id": "ab",
+          "kg_id": "4e71ece190e47455f7ae8b31d80dd3a9",
+          "weight": 0.4999999999999998
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "d14eb3961c1f7388e1d825087793b09c",
+          "weight": 0.9952594092303608
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "d614c7ce9753c9c96776b0b8c0496b90",
+          "weight": 0.4999999999999998
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "4a11a33f29fdbe47355079b7f43d97d0",
+          "weight": 0.6772190444071822
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "a6dd784998583735c9cdcae7246c05f3",
+          "weight": 0.4999999999999998
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "ec69907b8aa355c68a3028d491774cb8",
+          "weight": 0.4999999999999998
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "62769563de9abea21d061f71c8e1f092",
+          "weight": 0.4999999999999998
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "25ca4674bccf3d3623ec99ddd401fef8",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "477e260e9fd1ccd91159dbe57337c22e",
+          "weight": 0.4999999999999998
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "ead0c39f0b111e2554d42e09c6639da7",
+          "weight": 0.6772190444071822
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "5f9d7ec7475fcd03c7d0349c3d43ffd7",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "b81fdf71694595916d701accb5b538ac",
+          "weight": 0.7999999999999998
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "0f708fa3e227b1fc99acf54b86ab0067",
+          "weight": 0.4999999999999998
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "29805b4c97964fbcbc034e51592e1025",
+          "weight": 0.4999999999999998
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "5c92c1173e1b6b916355bc842d5c39e4",
+          "weight": 0.6772190444071822
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "4dcb2c732371e398b09ec26055f6359b",
+          "weight": 0.4999999999999998
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "48bfeb51ce3308d17910fcf7e55fe738",
+          "weight": 0.4999999999999998
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "45bb9997c8ac47225836c8e74cf91b5a",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "498c4c27bfd963f51fa822ad7f5a43cc",
+          "weight": 0.4999999999999998
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "14403bd92938ce4daec86a4771bf62e5",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "1f6d1af9c9790d9e764acbcefa529560",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "b10e8f04da87590a3f4594b55cb5f622",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "b350a7cdeb917e5427a848255024e654",
+          "weight": 0.4999999999999998
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "d30fdf6603478e158753fa54579c3bc8",
+          "weight": 0.4999999999999998
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "4c31cfcb4fcca8119bacadf5ff9c7c3f",
+          "weight": 0.4999999999999998
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "27e2d9c80f455b07035189d2d2185cc7",
+          "weight": 0.4999999999999998
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "444737174a86b6215191c9ac6115486b",
+          "weight": 0.4999999999999998
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "3f2dce542d551845ef737b2104a0a382",
+          "weight": 0.4999999999999998
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "f07c7b7ecfe8842148bd274046d16b91",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "926bbe3b8fa81d53f421602d766bccde",
+          "weight": 0.4999999999999998
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "43821d8754c5fd847b24ae5bff93cf0b",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "faf12afc64a27e030125dd3011fcff06",
+          "weight": 0.6772190444071822
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "7e2638ffd0752352debdae9307986f8d",
+          "weight": 0.4999999999999998
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "46d04f20397875b7376435c704c3bd02",
+          "weight": 0.4999999999999998
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "f35fb52da54f92f60696a99e84bfa51a",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "ecd1e07e353f9416c93c3e9b5e098d77",
+          "weight": 0.4999999999999998
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "9b613f3b2cf64f7a0b7ca99f716d67d6",
+          "weight": 0.9996952148735141
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "8efc24e375e9f21c0dcabd50d9df36e2",
+          "weight": 0.4999999999999998
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "b59a6c9652482f7a0b9f83afc9ae4146",
+          "weight": 0.4999999999999998
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "4e71ece190e47455f7ae8b31d80dd3a9",
+          "weight": 0.4999999999999998
+        },
+        {
+          "qg_id": "s0",
+          "kg_id": "dfd0579f-ed83-4cd1-b1fd-018dc45d0aa0",
+          "weight": 1.0
+        },
+        {
+          "qg_id": "s2",
+          "kg_id": "ac91e8d3-25b2-4a33-a705-53bb9e992169",
+          "weight": 0.0
+        },
+        {
+          "qg_id": "s5",
+          "kg_id": "1d8103c5-ec7f-4113-b748-a831f50348ec",
+          "weight": 0.35494629941051015
+        },
+        {
+          "qg_id": "s7",
+          "kg_id": "10cc973f-a2c3-425a-88fc-053d40f9d05c",
+          "weight": 0.08212742799994421
+        },
+        {
+          "qg_id": "s9",
+          "kg_id": "6dcc0290-4a57-4641-841e-7b7bce0c4dfa",
+          "weight": 0.0043642394266718565
+        },
+        {
+          "qg_id": "s11",
+          "kg_id": "785dec49-b2e6-4aed-a3d4-3ccf5ef5ba9a",
+          "weight": 0.03427319653363736
+        },
+        {
+          "qg_id": "s12",
+          "kg_id": "0ed76ed3-1ae6-4f2b-90b6-5af65e71863e",
+          "weight": 0.004461175571339071
+        },
+        {
+          "qg_id": "s15",
+          "kg_id": "92bd59d3-ae8b-4d45-b4be-c9edc87fffb9",
+          "weight": 0.07110386057201845
+        },
+        {
+          "qg_id": "s16",
+          "kg_id": "4d694c72-5629-4e7b-9210-3feb7d892a36",
+          "weight": 0.00968624868675172
+        },
+        {
+          "qg_id": "s18",
+          "kg_id": "f235abe9-d66c-4777-aa7a-0b7c25a56a83",
+          "weight": 0.04000789911277636
+        },
+        {
+          "qg_id": "s19",
+          "kg_id": "b700e850-b64b-4b7c-b2ae-0bad66f71a3e",
+          "weight": 0.019762199631277122
+        },
+        {
+          "qg_id": "s20",
+          "kg_id": "c52e233d-3864-4615-afb9-6fb1103a22a9",
+          "weight": 0.07670347341815309
+        },
+        {
+          "qg_id": "s25",
+          "kg_id": "a782b019-3deb-4df6-8e5f-a5e00606d2bf",
+          "weight": 0.008965406293893974
+        },
+        {
+          "qg_id": "s26",
+          "kg_id": "33f47eee-3df3-44e6-a794-6c0afb0c5e5b",
+          "weight": 0.021531300514223473
+        },
+        {
+          "qg_id": "s27",
+          "kg_id": "9392cd8f-8cf6-465a-bb1f-5af5a9db2690",
+          "weight": 0.0
+        },
+        {
+          "qg_id": "s28",
+          "kg_id": "d5dbfcb3-012b-4a93-b08d-7977d3227c2b",
+          "weight": 0.0476342062535382
+        },
+        {
+          "qg_id": "s29",
+          "kg_id": "14b13cae-5681-41a6-9bd2-b5b5fec969a3",
+          "weight": 0.001253603791511848
+        },
+        {
+          "qg_id": "s31",
+          "kg_id": "04c630e7-f050-436a-bd3b-cc9ab8d370a3",
+          "weight": 0.2946421395968455
+        },
+        {
+          "qg_id": "s32",
+          "kg_id": "a59f79ae-261d-464d-bdd1-b42a2ef73bcf",
+          "weight": 0.008116334141268888
+        },
+        {
+          "qg_id": "s35",
+          "kg_id": "90b99036-281c-47a0-af2e-22722581baf5",
+          "weight": 0.002457651043953346
+        },
+        {
+          "qg_id": "s36",
+          "kg_id": "ad82daf4-f7d4-4b7a-ab61-a6521ac60cac",
+          "weight": 0.07502710580926264
+        },
+        {
+          "qg_id": "s37",
+          "kg_id": "a1d12a86-1869-40c0-b989-7dddb20fd3e3",
+          "weight": 0.043592053932963504
+        },
+        {
+          "qg_id": "s38",
+          "kg_id": "4c101a2b-dcd8-4ef5-833f-3bd6633e1ceb",
+          "weight": 0.25356645531326705
+        }
+      ],
+      "score": 109.10848778735631
+    },
+    {
+      "node_bindings": [
+        {
+          "qg_id": "a",
+          "kg_id": [
+            "MONDO:0005090"
+          ]
+        },
+        {
+          "qg_id": "b",
+          "kg_id": [
+            "CHEBI:8707",
+            "MESH:D014282",
+            "CHEBI:7735",
+            "CHEBI:5613",
+            "CHEBI:31236",
+            "MESH:D001712",
+            "CHEBI:10119",
+            "MESH:D011398",
+            "MESH:D008653",
+            "MESH:D013469",
+            "MESH:D005473",
+            "CHEBI:3766",
+            "MESH:D013881",
+            "CHEBI:70735",
+            "MESH:D011352",
+            "CHEBI:8871"
+          ],
+          "enriched_nodes": [
+            "MONDO:0004985"
+          ],
+          "p_value": 6.484880857667477e-43,
+          "coalescence_method": "graph_enrichment"
+        },
+        {
+          "qg_id": "extra_qn_0",
+          "kg_id": [
+            "MONDO:0004985"
+          ]
+        }
+      ],
+      "edge_bindings": [
+        {
+          "qg_id": "ab",
+          "kg_id": "d14eb3961c1f7388e1d825087793b09c",
+          "weight": 0.9952594092303608
+        },
+        {
+          "qg_id": "ab",
+          "kg_id": "14403bd92938ce4daec86a4771bf62e5",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "ab",
+          "kg_id": "5f9d7ec7475fcd03c7d0349c3d43ffd7",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "ab",
+          "kg_id": "7e2638ffd0752352debdae9307986f8d",
+          "weight": 0.4999999999999998
+        },
+        {
+          "qg_id": "ab",
+          "kg_id": "b10e8f04da87590a3f4594b55cb5f622",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "ab",
+          "kg_id": "5c92c1173e1b6b916355bc842d5c39e4",
+          "weight": 0.6772190444071822
+        },
+        {
+          "qg_id": "ab",
+          "kg_id": "d614c7ce9753c9c96776b0b8c0496b90",
+          "weight": 0.4999999999999998
+        },
+        {
+          "qg_id": "ab",
+          "kg_id": "25ca4674bccf3d3623ec99ddd401fef8",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "ab",
+          "kg_id": "4c31cfcb4fcca8119bacadf5ff9c7c3f",
+          "weight": 0.4999999999999998
+        },
+        {
+          "qg_id": "ab",
+          "kg_id": "f35fb52da54f92f60696a99e84bfa51a",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "ab",
+          "kg_id": "444737174a86b6215191c9ac6115486b",
+          "weight": 0.4999999999999998
+        },
+        {
+          "qg_id": "ab",
+          "kg_id": "8efc24e375e9f21c0dcabd50d9df36e2",
+          "weight": 0.4999999999999998
+        },
+        {
+          "qg_id": "ab",
+          "kg_id": "f07c7b7ecfe8842148bd274046d16b91",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "ab",
+          "kg_id": "45bb9997c8ac47225836c8e74cf91b5a",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "ab",
+          "kg_id": "43821d8754c5fd847b24ae5bff93cf0b",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "ab",
+          "kg_id": "ead0c39f0b111e2554d42e09c6639da7",
+          "weight": 0.6772190444071822
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "6008916285095953533",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "4154493370753010689",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "-7507305372605831862",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "6112799945122878599",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "-7711103270866585879",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "-375984081016907419",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "-4349798301881810185",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "8105171369240467018",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "8655502730642576852",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "-6103542527948243491",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "5896744110281421124",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "5038839236277679657",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "-4732781122994517410",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "6878025413863037439",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "-5513087202338337169",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "-7950429506698507531",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "s5",
+          "kg_id": "1d8103c5-ec7f-4113-b748-a831f50348ec",
+          "weight": 0.35494629941051015
+        },
+        {
+          "qg_id": "s11",
+          "kg_id": "785dec49-b2e6-4aed-a3d4-3ccf5ef5ba9a",
+          "weight": 0.03427319653363736
+        },
+        {
+          "qg_id": "s15",
+          "kg_id": "92bd59d3-ae8b-4d45-b4be-c9edc87fffb9",
+          "weight": 0.07110386057201845
+        },
+        {
+          "qg_id": "s25",
+          "kg_id": "a782b019-3deb-4df6-8e5f-a5e00606d2bf",
+          "weight": 0.008965406293893974
+        },
+        {
+          "qg_id": "s26",
+          "kg_id": "33f47eee-3df3-44e6-a794-6c0afb0c5e5b",
+          "weight": 0.021531300514223473
+        },
+        {
+          "qg_id": "s28",
+          "kg_id": "d5dbfcb3-012b-4a93-b08d-7977d3227c2b",
+          "weight": 0.0476342062535382
+        },
+        {
+          "qg_id": "s31",
+          "kg_id": "04c630e7-f050-436a-bd3b-cc9ab8d370a3",
+          "weight": 0.2946421395968455
+        },
+        {
+          "qg_id": "s36",
+          "kg_id": "ad82daf4-f7d4-4b7a-ab61-a6521ac60cac",
+          "weight": 0.07502710580926264
+        },
+        {
+          "qg_id": "s40",
+          "kg_id": "6fea48cb-3947-4d71-a38a-ade9fbfaf945",
+          "weight": 0.0
+        },
+        {
+          "qg_id": "s42",
+          "kg_id": "4f6bc436-44c3-4d60-a836-21075ce40186",
+          "weight": 0.006438437042515233
+        },
+        {
+          "qg_id": "s46",
+          "kg_id": "a7356a59-17ee-4fa2-8eaf-1b8bd795d8ec",
+          "weight": 0.0021874714961489516
+        },
+        {
+          "qg_id": "s48",
+          "kg_id": "32e73478-16d0-4fa2-808a-5bdb696bc4e8",
+          "weight": 0.0
+        },
+        {
+          "qg_id": "s49",
+          "kg_id": "12c096b5-fb5c-4548-90e4-240d1f6f45ce",
+          "weight": 0.0019029678181567977
+        },
+        {
+          "qg_id": "s50",
+          "kg_id": "25b66ce3-bdab-40f9-8f6f-1884448a7738",
+          "weight": 0.021961868873161094
+        },
+        {
+          "qg_id": "s51",
+          "kg_id": "466f214d-a79d-41fb-aaf0-03216d0e304f",
+          "weight": 0.13715428886245196
+        },
+        {
+          "qg_id": "s53",
+          "kg_id": "22265ef9-6d7e-4cb4-8857-8c0910ff2bc3",
+          "weight": 0.05403710921553473
+        },
+        {
+          "qg_id": "s55",
+          "kg_id": "7218b1f7-b1fc-48cd-83ef-47c9a9728832",
+          "weight": 0.006603866924795199
+        }
+      ],
+      "score": 1437.196623922414
+    },
+    {
+      "node_bindings": [
+        {
+          "qg_id": "a",
+          "kg_id": [
+            "MONDO:0005090"
+          ]
+        },
+        {
+          "qg_id": "b",
+          "kg_id": [
+            "CHEBI:8707",
+            "CHEBI:7735",
+            "CHEBI:5613",
+            "CHEBI:31236",
+            "CHEBI:65173",
+            "MESH:D013881",
+            "CHEBI:10119",
+            "MESH:D005473",
+            "CHEBI:3766",
+            "MESH:D008140",
+            "CHEBI:70735",
+            "CHEBI:8871"
+          ],
+          "enriched_nodes": [
+            "MONDO:0011552"
+          ],
+          "p_value": 9.698255571218461e-34,
+          "coalescence_method": "graph_enrichment"
+        },
+        {
+          "qg_id": "extra_qn_0",
+          "kg_id": [
+            "MONDO:0011552"
+          ]
+        }
+      ],
+      "edge_bindings": [
+        {
+          "qg_id": "ab",
+          "kg_id": "d14eb3961c1f7388e1d825087793b09c",
+          "weight": 0.9952594092303608
+        },
+        {
+          "qg_id": "ab",
+          "kg_id": "14403bd92938ce4daec86a4771bf62e5",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "ab",
+          "kg_id": "5f9d7ec7475fcd03c7d0349c3d43ffd7",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "ab",
+          "kg_id": "1f6d1af9c9790d9e764acbcefa529560",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "ab",
+          "kg_id": "b10e8f04da87590a3f4594b55cb5f622",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "ab",
+          "kg_id": "d614c7ce9753c9c96776b0b8c0496b90",
+          "weight": 0.4999999999999998
+        },
+        {
+          "qg_id": "ab",
+          "kg_id": "25ca4674bccf3d3623ec99ddd401fef8",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "ab",
+          "kg_id": "f35fb52da54f92f60696a99e84bfa51a",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "ab",
+          "kg_id": "4a11a33f29fdbe47355079b7f43d97d0",
+          "weight": 0.6772190444071822
+        },
+        {
+          "qg_id": "ab",
+          "kg_id": "f07c7b7ecfe8842148bd274046d16b91",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "ab",
+          "kg_id": "45bb9997c8ac47225836c8e74cf91b5a",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "ab",
+          "kg_id": "43821d8754c5fd847b24ae5bff93cf0b",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "-3430614955284991846",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "-5689304263517049529",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "-4281548860317661491",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "-7514071192782330151",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "-2036566501268119119",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "-3602937035054302897",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "-2821951771878666050",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "-7407705456216866919",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "-3692334211239932235",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "8721791765556081975",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "2672134749508767710",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "-5382694374086368082",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "s7",
+          "kg_id": "10cc973f-a2c3-425a-88fc-053d40f9d05c",
+          "weight": 0.08212742799994421
+        },
+        {
+          "qg_id": "s28",
+          "kg_id": "d5dbfcb3-012b-4a93-b08d-7977d3227c2b",
+          "weight": 0.0476342062535382
+        },
+        {
+          "qg_id": "s31",
+          "kg_id": "04c630e7-f050-436a-bd3b-cc9ab8d370a3",
+          "weight": 0.2946421395968455
+        },
+        {
+          "qg_id": "s63",
+          "kg_id": "c70e3932-1f28-48cf-80ac-1b3359d91c28",
+          "weight": 0.009464589380994148
+        },
+        {
+          "qg_id": "s67",
+          "kg_id": "2cd2b487-428d-4416-b238-3e4c2bda43fd",
+          "weight": 0.02179141298206111
+        }
+      ],
+      "score": 109.10848778735631
+    },
+    {
+      "node_bindings": [
+        {
+          "qg_id": "a",
+          "kg_id": [
+            "MONDO:0005090"
+          ]
+        },
+        {
+          "qg_id": "b",
+          "kg_id": [
+            "MESH:D000069470",
+            "CHEBI:5613",
+            "CHEBI:31236",
+            "MESH:D013881",
+            "CHEBI:10119",
+            "MESH:D011398",
+            "MESH:D000077582",
+            "CHEBI:3766",
+            "MESH:D008972",
+            "MESH:C007761",
+            "MESH:D011352",
+            "CHEBI:8871"
+          ],
+          "enriched_nodes": [
+            "MONDO:0019790"
+          ],
+          "p_value": 1.6294555775496054e-32,
+          "coalescence_method": "graph_enrichment"
+        },
+        {
+          "qg_id": "extra_qn_0",
+          "kg_id": [
+            "MONDO:0019790"
+          ]
+        }
+      ],
+      "edge_bindings": [
+        {
+          "qg_id": "ab",
+          "kg_id": "d14eb3961c1f7388e1d825087793b09c",
+          "weight": 0.9952594092303608
+        },
+        {
+          "qg_id": "ab",
+          "kg_id": "5f9d7ec7475fcd03c7d0349c3d43ffd7",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "ab",
+          "kg_id": "b81fdf71694595916d701accb5b538ac",
+          "weight": 0.7999999999999998
+        },
+        {
+          "qg_id": "ab",
+          "kg_id": "faf12afc64a27e030125dd3011fcff06",
+          "weight": 0.6772190444071822
+        },
+        {
+          "qg_id": "ab",
+          "kg_id": "0f708fa3e227b1fc99acf54b86ab0067",
+          "weight": 0.4999999999999998
+        },
+        {
+          "qg_id": "ab",
+          "kg_id": "5c92c1173e1b6b916355bc842d5c39e4",
+          "weight": 0.6772190444071822
+        },
+        {
+          "qg_id": "ab",
+          "kg_id": "f35fb52da54f92f60696a99e84bfa51a",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "ab",
+          "kg_id": "444737174a86b6215191c9ac6115486b",
+          "weight": 0.4999999999999998
+        },
+        {
+          "qg_id": "ab",
+          "kg_id": "9b613f3b2cf64f7a0b7ca99f716d67d6",
+          "weight": 0.9996952148735141
+        },
+        {
+          "qg_id": "ab",
+          "kg_id": "f07c7b7ecfe8842148bd274046d16b91",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "ab",
+          "kg_id": "45bb9997c8ac47225836c8e74cf91b5a",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "ab",
+          "kg_id": "43821d8754c5fd847b24ae5bff93cf0b",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "6686572420378851751",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "-9005582744011621404",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "6523513369983346474",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "7708493085475630173",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "9191689101766575094",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "6490798625887314518",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "4325772177267623447",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "-2600856695005313164",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "8739461348402766836",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "-884870587413398727",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "672300843764922289",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "8000298095778413586",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "s11",
+          "kg_id": "785dec49-b2e6-4aed-a3d4-3ccf5ef5ba9a",
+          "weight": 0.03427319653363736
+        },
+        {
+          "qg_id": "s12",
+          "kg_id": "0ed76ed3-1ae6-4f2b-90b6-5af65e71863e",
+          "weight": 0.004461175571339071
+        },
+        {
+          "qg_id": "s18",
+          "kg_id": "f235abe9-d66c-4777-aa7a-0b7c25a56a83",
+          "weight": 0.04000789911277636
+        },
+        {
+          "qg_id": "s25",
+          "kg_id": "a782b019-3deb-4df6-8e5f-a5e00606d2bf",
+          "weight": 0.008965406293893974
+        },
+        {
+          "qg_id": "s31",
+          "kg_id": "04c630e7-f050-436a-bd3b-cc9ab8d370a3",
+          "weight": 0.2946421395968455
+        },
+        {
+          "qg_id": "s37",
+          "kg_id": "a1d12a86-1869-40c0-b989-7dddb20fd3e3",
+          "weight": 0.043592053932963504
+        },
+        {
+          "qg_id": "s38",
+          "kg_id": "4c101a2b-dcd8-4ef5-833f-3bd6633e1ceb",
+          "weight": 0.25356645531326705
+        },
+        {
+          "qg_id": "s71",
+          "kg_id": "89b8696d-cf7b-4c32-8c8a-d99baf56f4bd",
+          "weight": 0.005896481256777886
+        },
+        {
+          "qg_id": "s74",
+          "kg_id": "b0b92e9a-b0ad-449b-8423-3ba9c197c308",
+          "weight": 0.016897414449289938
+        },
+        {
+          "qg_id": "s76",
+          "kg_id": "46f1c3f1-5cfb-40be-b55f-c30eb1d18190",
+          "weight": 0.0058412299464958295
+        },
+        {
+          "qg_id": "s77",
+          "kg_id": "c2b3561c-998a-44ef-8a8e-7f1d9adaceb2",
+          "weight": 0.010906982710634727
+        },
+        {
+          "qg_id": "s79",
+          "kg_id": "3253a02d-e41f-4000-bd66-e045c2dd0ed1",
+          "weight": 0.0020439958006335246
+        },
+        {
+          "qg_id": "s80",
+          "kg_id": "ccda52b7-7adc-4c0c-9fc7-2d8ea3bc2f1c",
+          "weight": 0.0020491828152684466
+        },
+        {
+          "qg_id": "s81",
+          "kg_id": "da172c1d-6577-4b6c-adb7-be48564bc5cc",
+          "weight": 0.0034090192008799924
+        }
+      ],
+      "score": 6161.777856681035
+    },
+    {
+      "node_bindings": [
+        {
+          "qg_id": "a",
+          "kg_id": [
+            "MONDO:0005090"
+          ]
+        },
+        {
+          "qg_id": "b",
+          "kg_id": [
+            "CHEBI:7735",
+            "MESH:D000069470",
+            "CHEBI:5613",
+            "MESH:D013881",
+            "CHEBI:10119",
+            "MESH:D013469",
+            "MESH:D005473",
+            "CHEBI:3766",
+            "MESH:D008972",
+            "MESH:D000077582",
+            "CHEBI:8871"
+          ],
+          "enriched_nodes": [
+            "MONDO:0005804"
+          ],
+          "p_value": 9.883433767071497e-31,
+          "coalescence_method": "graph_enrichment"
+        },
+        {
+          "qg_id": "extra_qn_0",
+          "kg_id": [
+            "MONDO:0005804"
+          ]
+        }
+      ],
+      "edge_bindings": [
+        {
+          "qg_id": "ab",
+          "kg_id": "d14eb3961c1f7388e1d825087793b09c",
+          "weight": 0.9952594092303608
+        },
+        {
+          "qg_id": "ab",
+          "kg_id": "5f9d7ec7475fcd03c7d0349c3d43ffd7",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "ab",
+          "kg_id": "b81fdf71694595916d701accb5b538ac",
+          "weight": 0.7999999999999998
+        },
+        {
+          "qg_id": "ab",
+          "kg_id": "0f708fa3e227b1fc99acf54b86ab0067",
+          "weight": 0.4999999999999998
+        },
+        {
+          "qg_id": "ab",
+          "kg_id": "b10e8f04da87590a3f4594b55cb5f622",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "ab",
+          "kg_id": "d614c7ce9753c9c96776b0b8c0496b90",
+          "weight": 0.4999999999999998
+        },
+        {
+          "qg_id": "ab",
+          "kg_id": "4c31cfcb4fcca8119bacadf5ff9c7c3f",
+          "weight": 0.4999999999999998
+        },
+        {
+          "qg_id": "ab",
+          "kg_id": "f35fb52da54f92f60696a99e84bfa51a",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "ab",
+          "kg_id": "9b613f3b2cf64f7a0b7ca99f716d67d6",
+          "weight": 0.9996952148735141
+        },
+        {
+          "qg_id": "ab",
+          "kg_id": "f07c7b7ecfe8842148bd274046d16b91",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "ab",
+          "kg_id": "43821d8754c5fd847b24ae5bff93cf0b",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "-5870362081136959670",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "1902255578605881614",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "113269640907308629",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "-1310006511909716744",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "-5214831124842227754",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "3957404463100624681",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "277579601087748283",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "-3576357953206954376",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "-1061304296024582542",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "-5625489836607458262",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "-4531208579869110648",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "s5",
+          "kg_id": "1d8103c5-ec7f-4113-b748-a831f50348ec",
+          "weight": 0.35494629941051015
+        },
+        {
+          "qg_id": "s12",
+          "kg_id": "0ed76ed3-1ae6-4f2b-90b6-5af65e71863e",
+          "weight": 0.004461175571339071
+        },
+        {
+          "qg_id": "s18",
+          "kg_id": "f235abe9-d66c-4777-aa7a-0b7c25a56a83",
+          "weight": 0.04000789911277636
+        },
+        {
+          "qg_id": "s28",
+          "kg_id": "d5dbfcb3-012b-4a93-b08d-7977d3227c2b",
+          "weight": 0.0476342062535382
+        },
+        {
+          "qg_id": "s31",
+          "kg_id": "04c630e7-f050-436a-bd3b-cc9ab8d370a3",
+          "weight": 0.2946421395968455
+        },
+        {
+          "qg_id": "s38",
+          "kg_id": "4c101a2b-dcd8-4ef5-833f-3bd6633e1ceb",
+          "weight": 0.25356645531326705
+        },
+        {
+          "qg_id": "s85",
+          "kg_id": "2d4f57ea-b890-4c05-ab13-7106b9018897",
+          "weight": 0.0009514589971131304
+        },
+        {
+          "qg_id": "s87",
+          "kg_id": "133c768b-21ae-4c00-976d-012d980a24c1",
+          "weight": 0.0030357055793304166
+        },
+        {
+          "qg_id": "s89",
+          "kg_id": "8c81633e-4c79-4065-9cad-e155bde1af22",
+          "weight": 0.11012652448298677
+        },
+        {
+          "qg_id": "s90",
+          "kg_id": "d17e8e91-3c7c-4d85-bd97-b93d770a9a43",
+          "weight": 0.004675873507506312
+        },
+        {
+          "qg_id": "s92",
+          "kg_id": "c1a7a0ec-712f-4d42-9f82-aea353340778",
+          "weight": 0.001349578895597503
+        },
+        {
+          "qg_id": "s93",
+          "kg_id": "363afc69-9a96-467a-904f-3f6a001adad0",
+          "weight": 0.02322408207147353
+        }
+      ],
+      "score": 6161.777856681035
+    },
+    {
+      "node_bindings": [
+        {
+          "qg_id": "a",
+          "kg_id": [
+            "MONDO:0005090"
+          ]
+        },
+        {
+          "qg_id": "b",
+          "kg_id": [
+            "CHEBI:7735",
+            "MESH:D000069470",
+            "CHEBI:5613",
+            "CHEBI:31236",
+            "CHEBI:10119",
+            "MESH:D008653",
+            "MESH:D005473",
+            "CHEBI:3766",
+            "MESH:D013881",
+            "MESH:D003990",
+            "MESH:D000077582",
+            "CHEBI:8871"
+          ],
+          "enriched_nodes": [
+            "MONDO:0006731"
+          ],
+          "p_value": 4.0320721261889455e-29,
+          "coalescence_method": "graph_enrichment"
+        },
+        {
+          "qg_id": "extra_qn_0",
+          "kg_id": [
+            "MONDO:0006731"
+          ]
+        }
+      ],
+      "edge_bindings": [
+        {
+          "qg_id": "ab",
+          "kg_id": "d14eb3961c1f7388e1d825087793b09c",
+          "weight": 0.9952594092303608
+        },
+        {
+          "qg_id": "ab",
+          "kg_id": "5f9d7ec7475fcd03c7d0349c3d43ffd7",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "ab",
+          "kg_id": "0f708fa3e227b1fc99acf54b86ab0067",
+          "weight": 0.4999999999999998
+        },
+        {
+          "qg_id": "ab",
+          "kg_id": "b10e8f04da87590a3f4594b55cb5f622",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "ab",
+          "kg_id": "b350a7cdeb917e5427a848255024e654",
+          "weight": 0.4999999999999998
+        },
+        {
+          "qg_id": "ab",
+          "kg_id": "d614c7ce9753c9c96776b0b8c0496b90",
+          "weight": 0.4999999999999998
+        },
+        {
+          "qg_id": "ab",
+          "kg_id": "f35fb52da54f92f60696a99e84bfa51a",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "ab",
+          "kg_id": "9b613f3b2cf64f7a0b7ca99f716d67d6",
+          "weight": 0.9996952148735141
+        },
+        {
+          "qg_id": "ab",
+          "kg_id": "8efc24e375e9f21c0dcabd50d9df36e2",
+          "weight": 0.4999999999999998
+        },
+        {
+          "qg_id": "ab",
+          "kg_id": "f07c7b7ecfe8842148bd274046d16b91",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "ab",
+          "kg_id": "45bb9997c8ac47225836c8e74cf91b5a",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "ab",
+          "kg_id": "43821d8754c5fd847b24ae5bff93cf0b",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "5900986011888128473",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "-5198590934450462318",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "3228142757943468432",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "7946187969751317843",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "778781801369598350",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "409316489987944385",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "-4011029275528409363",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "-6972979114562138506",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "7249108970589608202",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "4800661422038868768",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "6019138631983979384",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "-6601825417324012366",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "s9",
+          "kg_id": "6dcc0290-4a57-4641-841e-7b7bce0c4dfa",
+          "weight": 0.0043642394266718565
+        },
+        {
+          "qg_id": "s12",
+          "kg_id": "0ed76ed3-1ae6-4f2b-90b6-5af65e71863e",
+          "weight": 0.004461175571339071
+        },
+        {
+          "qg_id": "s26",
+          "kg_id": "33f47eee-3df3-44e6-a794-6c0afb0c5e5b",
+          "weight": 0.021531300514223473
+        },
+        {
+          "qg_id": "s28",
+          "kg_id": "d5dbfcb3-012b-4a93-b08d-7977d3227c2b",
+          "weight": 0.0476342062535382
+        },
+        {
+          "qg_id": "s31",
+          "kg_id": "04c630e7-f050-436a-bd3b-cc9ab8d370a3",
+          "weight": 0.2946421395968455
+        },
+        {
+          "qg_id": "s38",
+          "kg_id": "4c101a2b-dcd8-4ef5-833f-3bd6633e1ceb",
+          "weight": 0.25356645531326705
+        },
+        {
+          "qg_id": "s97",
+          "kg_id": "98bfa494-d719-4ab5-86bf-f30346817194",
+          "weight": 0.022957068217827503
+        },
+        {
+          "qg_id": "s101",
+          "kg_id": "556490ba-b8ba-4530-9d65-3662d041e434",
+          "weight": 0.002586923103620631
+        },
+        {
+          "qg_id": "s102",
+          "kg_id": "5e455b3f-9cb5-4bb9-bf4a-6fffa3f4007c",
+          "weight": 0.11060410669365783
+        },
+        {
+          "qg_id": "s104",
+          "kg_id": "0aa220af-34b7-4038-a9e6-ff5463190e07",
+          "weight": 0.03617213383676954
+        },
+        {
+          "qg_id": "s105",
+          "kg_id": "ce56e551-15fd-4e89-b765-70c19c04282f",
+          "weight": 0.0007111669524679787
+        },
+        {
+          "qg_id": "s106",
+          "kg_id": "aa34fdb1-80a5-4506-9091-0f5cf8337258",
+          "weight": 0.0272748446447868
+        }
+      ],
+      "score": 6161.777856681035
+    },
+    {
+      "node_bindings": [
+        {
+          "qg_id": "a",
+          "kg_id": [
+            "MONDO:0005090"
+          ]
+        },
+        {
+          "qg_id": "b",
+          "kg_id": [
+            "MESH:D011433",
+            "CHEBI:7735",
+            "MESH:D000069470",
+            "CHEBI:5613",
+            "CHEBI:31236",
+            "MESH:D013881",
+            "MESH:D011398",
+            "MESH:D005473",
+            "CHEBI:3766",
+            "MESH:D008140",
+            "MESH:D003990",
+            "CHEBI:8871"
+          ],
+          "enriched_nodes": [
+            "MONDO:0005466"
+          ],
+          "p_value": 9.655910503566156e-29,
+          "coalescence_method": "graph_enrichment"
+        },
+        {
+          "qg_id": "extra_qn_0",
+          "kg_id": [
+            "MONDO:0005466"
+          ]
+        }
+      ],
+      "edge_bindings": [
+        {
+          "qg_id": "ab",
+          "kg_id": "d14eb3961c1f7388e1d825087793b09c",
+          "weight": 0.9952594092303608
+        },
+        {
+          "qg_id": "ab",
+          "kg_id": "5f9d7ec7475fcd03c7d0349c3d43ffd7",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "ab",
+          "kg_id": "0f708fa3e227b1fc99acf54b86ab0067",
+          "weight": 0.4999999999999998
+        },
+        {
+          "qg_id": "ab",
+          "kg_id": "b10e8f04da87590a3f4594b55cb5f622",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "ab",
+          "kg_id": "b350a7cdeb917e5427a848255024e654",
+          "weight": 0.4999999999999998
+        },
+        {
+          "qg_id": "ab",
+          "kg_id": "d614c7ce9753c9c96776b0b8c0496b90",
+          "weight": 0.4999999999999998
+        },
+        {
+          "qg_id": "ab",
+          "kg_id": "f35fb52da54f92f60696a99e84bfa51a",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "ab",
+          "kg_id": "444737174a86b6215191c9ac6115486b",
+          "weight": 0.4999999999999998
+        },
+        {
+          "qg_id": "ab",
+          "kg_id": "4a11a33f29fdbe47355079b7f43d97d0",
+          "weight": 0.6772190444071822
+        },
+        {
+          "qg_id": "ab",
+          "kg_id": "f07c7b7ecfe8842148bd274046d16b91",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "ab",
+          "kg_id": "45bb9997c8ac47225836c8e74cf91b5a",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "ab",
+          "kg_id": "b59a6c9652482f7a0b9f83afc9ae4146",
+          "weight": 0.4999999999999998
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "-1082558950480460648",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "-8110574637392439364",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "-2018046158300641334",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "8044659037332195408",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "2469858430708297479",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "1932055102892904387",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "-6949345259046099169",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "-8775666285376168509",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "-8029565172048478246",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "-7684933401502972409",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "-4902033109589333640",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "-563570001699188780",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "s2",
+          "kg_id": "ac91e8d3-25b2-4a33-a705-53bb9e992169",
+          "weight": 0.0
+        },
+        {
+          "qg_id": "s7",
+          "kg_id": "10cc973f-a2c3-425a-88fc-053d40f9d05c",
+          "weight": 0.08212742799994421
+        },
+        {
+          "qg_id": "s9",
+          "kg_id": "6dcc0290-4a57-4641-841e-7b7bce0c4dfa",
+          "weight": 0.0043642394266718565
+        },
+        {
+          "qg_id": "s12",
+          "kg_id": "0ed76ed3-1ae6-4f2b-90b6-5af65e71863e",
+          "weight": 0.004461175571339071
+        },
+        {
+          "qg_id": "s25",
+          "kg_id": "a782b019-3deb-4df6-8e5f-a5e00606d2bf",
+          "weight": 0.008965406293893974
+        },
+        {
+          "qg_id": "s28",
+          "kg_id": "d5dbfcb3-012b-4a93-b08d-7977d3227c2b",
+          "weight": 0.0476342062535382
+        },
+        {
+          "qg_id": "s31",
+          "kg_id": "04c630e7-f050-436a-bd3b-cc9ab8d370a3",
+          "weight": 0.2946421395968455
+        },
+        {
+          "qg_id": "s109",
+          "kg_id": "8dec875d-2abd-4a26-a42a-bc52a3dee6fd",
+          "weight": 0.0
+        },
+        {
+          "qg_id": "s111",
+          "kg_id": "bd862fa7-f909-4bb1-a48c-538c6825017f",
+          "weight": 0.005875425743998353
+        },
+        {
+          "qg_id": "s115",
+          "kg_id": "1a862457-3c57-4013-a433-747657293cc2",
+          "weight": 0.0010097020896031594
+        },
+        {
+          "qg_id": "s116",
+          "kg_id": "1be0afd9-bd9d-47d8-87f7-bf10cf75f492",
+          "weight": 0.00852814049456918
+        },
+        {
+          "qg_id": "s118",
+          "kg_id": "fff1059c-b59d-4cf0-a378-b71db71c01fc",
+          "weight": 0.003776204502989211
+        }
+      ],
+      "score": 6161.777856681035
+    },
+    {
+      "node_bindings": [
+        {
+          "qg_id": "a",
+          "kg_id": [
+            "MONDO:0005090"
+          ]
+        },
+        {
+          "qg_id": "b",
+          "kg_id": [
+            "MESH:C522667",
+            "MESH:D011433",
+            "CHEBI:7735",
+            "MESH:D000069470",
+            "CHEBI:31236",
+            "MESH:D012436",
+            "CHEBI:10119",
+            "MESH:D011398",
+            "CHEBI:3766",
+            "MESH:D008972",
+            "MESH:D014282",
+            "MESH:D000077582",
+            "CHEBI:8871"
+          ],
+          "enriched_nodes": [
+            "MONDO:0001220"
+          ],
+          "p_value": 1.873674780128358e-27,
+          "coalescence_method": "graph_enrichment"
+        },
+        {
+          "qg_id": "extra_qn_0",
+          "kg_id": [
+            "MONDO:0001220"
+          ]
+        }
+      ],
+      "edge_bindings": [
+        {
+          "qg_id": "ab",
+          "kg_id": "b81fdf71694595916d701accb5b538ac",
+          "weight": 0.7999999999999998
+        },
+        {
+          "qg_id": "ab",
+          "kg_id": "0f708fa3e227b1fc99acf54b86ab0067",
+          "weight": 0.4999999999999998
+        },
+        {
+          "qg_id": "ab",
+          "kg_id": "29805b4c97964fbcbc034e51592e1025",
+          "weight": 0.4999999999999998
+        },
+        {
+          "qg_id": "ab",
+          "kg_id": "b10e8f04da87590a3f4594b55cb5f622",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "ab",
+          "kg_id": "46d04f20397875b7376435c704c3bd02",
+          "weight": 0.4999999999999998
+        },
+        {
+          "qg_id": "ab",
+          "kg_id": "f35fb52da54f92f60696a99e84bfa51a",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "ab",
+          "kg_id": "444737174a86b6215191c9ac6115486b",
+          "weight": 0.4999999999999998
+        },
+        {
+          "qg_id": "ab",
+          "kg_id": "9b613f3b2cf64f7a0b7ca99f716d67d6",
+          "weight": 0.9996952148735141
+        },
+        {
+          "qg_id": "ab",
+          "kg_id": "f07c7b7ecfe8842148bd274046d16b91",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "ab",
+          "kg_id": "45bb9997c8ac47225836c8e74cf91b5a",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "ab",
+          "kg_id": "b59a6c9652482f7a0b9f83afc9ae4146",
+          "weight": 0.4999999999999998
+        },
+        {
+          "qg_id": "ab",
+          "kg_id": "43821d8754c5fd847b24ae5bff93cf0b",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "ab",
+          "kg_id": "ead0c39f0b111e2554d42e09c6639da7",
+          "weight": 0.6772190444071822
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "1284362363045701314",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "-3861606725632480322",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "-2721430935200047750",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "7793177503146015851",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "5465134243090038950",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "1821046102343364101",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "4199326379324748488",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "7808811803180987829",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "4888023147390638344",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "4447928982518789070",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "7511467792749227979",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "-1174456227016712231",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "7342738987638233672",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "s2",
+          "kg_id": "ac91e8d3-25b2-4a33-a705-53bb9e992169",
+          "weight": 0.0
+        },
+        {
+          "qg_id": "s12",
+          "kg_id": "0ed76ed3-1ae6-4f2b-90b6-5af65e71863e",
+          "weight": 0.004461175571339071
+        },
+        {
+          "qg_id": "s16",
+          "kg_id": "4d694c72-5629-4e7b-9210-3feb7d892a36",
+          "weight": 0.00968624868675172
+        },
+        {
+          "qg_id": "s18",
+          "kg_id": "f235abe9-d66c-4777-aa7a-0b7c25a56a83",
+          "weight": 0.04000789911277636
+        },
+        {
+          "qg_id": "s20",
+          "kg_id": "c52e233d-3864-4615-afb9-6fb1103a22a9",
+          "weight": 0.07670347341815309
+        },
+        {
+          "qg_id": "s25",
+          "kg_id": "a782b019-3deb-4df6-8e5f-a5e00606d2bf",
+          "weight": 0.008965406293893974
+        },
+        {
+          "qg_id": "s36",
+          "kg_id": "ad82daf4-f7d4-4b7a-ab61-a6521ac60cac",
+          "weight": 0.07502710580926264
+        },
+        {
+          "qg_id": "s38",
+          "kg_id": "4c101a2b-dcd8-4ef5-833f-3bd6633e1ceb",
+          "weight": 0.25356645531326705
+        },
+        {
+          "qg_id": "s123",
+          "kg_id": "831cbe4f-53f0-4bc7-abb1-da1110ab02e2",
+          "weight": 0.0
+        }
+      ],
+      "score": 6161.777856681035
+    },
+    {
+      "node_bindings": [
+        {
+          "qg_id": "a",
+          "kg_id": [
+            "MONDO:0005090"
+          ]
+        },
+        {
+          "qg_id": "b",
+          "kg_id": [
+            "MESH:D011433",
+            "CHEBI:7735",
+            "MESH:D000069470",
+            "MESH:D013881",
+            "CHEBI:10119",
+            "MESH:D013469",
+            "MESH:D005473",
+            "CHEBI:3766",
+            "MESH:D008140",
+            "CHEBI:8871"
+          ],
+          "enriched_nodes": [
+            "MONDO:0000947"
+          ],
+          "p_value": 2.1666161404028012e-27,
+          "coalescence_method": "graph_enrichment"
+        },
+        {
+          "qg_id": "extra_qn_0",
+          "kg_id": [
+            "MONDO:0000947"
+          ]
+        }
+      ],
+      "edge_bindings": [
+        {
+          "qg_id": "ab",
+          "kg_id": "d14eb3961c1f7388e1d825087793b09c",
+          "weight": 0.9952594092303608
+        },
+        {
+          "qg_id": "ab",
+          "kg_id": "0f708fa3e227b1fc99acf54b86ab0067",
+          "weight": 0.4999999999999998
+        },
+        {
+          "qg_id": "ab",
+          "kg_id": "b10e8f04da87590a3f4594b55cb5f622",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "ab",
+          "kg_id": "d614c7ce9753c9c96776b0b8c0496b90",
+          "weight": 0.4999999999999998
+        },
+        {
+          "qg_id": "ab",
+          "kg_id": "4c31cfcb4fcca8119bacadf5ff9c7c3f",
+          "weight": 0.4999999999999998
+        },
+        {
+          "qg_id": "ab",
+          "kg_id": "f35fb52da54f92f60696a99e84bfa51a",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "ab",
+          "kg_id": "4a11a33f29fdbe47355079b7f43d97d0",
+          "weight": 0.6772190444071822
+        },
+        {
+          "qg_id": "ab",
+          "kg_id": "f07c7b7ecfe8842148bd274046d16b91",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "ab",
+          "kg_id": "b59a6c9652482f7a0b9f83afc9ae4146",
+          "weight": 0.4999999999999998
+        },
+        {
+          "qg_id": "ab",
+          "kg_id": "43821d8754c5fd847b24ae5bff93cf0b",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "4637926927286489604",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "-4239673443003562808",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "7572156259469666611",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "7558865895637465431",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "6955043225709352755",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "2637751340779862147",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "4067348011150782440",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "1491531456521308224",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "-5759351193094264838",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "-6161827907572271092",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "s2",
+          "kg_id": "ac91e8d3-25b2-4a33-a705-53bb9e992169",
+          "weight": 0.0
+        },
+        {
+          "qg_id": "s5",
+          "kg_id": "1d8103c5-ec7f-4113-b748-a831f50348ec",
+          "weight": 0.35494629941051015
+        },
+        {
+          "qg_id": "s7",
+          "kg_id": "10cc973f-a2c3-425a-88fc-053d40f9d05c",
+          "weight": 0.08212742799994421
+        },
+        {
+          "qg_id": "s12",
+          "kg_id": "0ed76ed3-1ae6-4f2b-90b6-5af65e71863e",
+          "weight": 0.004461175571339071
+        },
+        {
+          "qg_id": "s28",
+          "kg_id": "d5dbfcb3-012b-4a93-b08d-7977d3227c2b",
+          "weight": 0.0476342062535382
+        },
+        {
+          "qg_id": "s31",
+          "kg_id": "04c630e7-f050-436a-bd3b-cc9ab8d370a3",
+          "weight": 0.2946421395968455
+        },
+        {
+          "qg_id": "s136",
+          "kg_id": "52b20a8d-a3e6-4a8b-b2b2-fdff59764f16",
+          "weight": 0.0016545996052257372
+        },
+        {
+          "qg_id": "s138",
+          "kg_id": "aea64c43-0b05-43cd-bc9c-0fb6c2d29c4b",
+          "weight": 0.00899151798387643
+        },
+        {
+          "qg_id": "s139",
+          "kg_id": "f8faf57b-262d-43b0-8d90-2195948db951",
+          "weight": 0.0028479243148284983
+        },
+        {
+          "qg_id": "s141",
+          "kg_id": "ac60ff30-08d7-4903-aab8-cc625f111bd5",
+          "weight": 0.0045219323849396975
+        },
+        {
+          "qg_id": "s142",
+          "kg_id": "0992ed71-8596-4f60-9b1e-92bff40285e6",
+          "weight": 0.051982800776879445
+        },
+        {
+          "qg_id": "s144",
+          "kg_id": "ca779dd6-bc10-4f95-b964-4dde6a137445",
+          "weight": 0.0027316704639692713
+        }
+      ],
+      "score": 6161.777856681035
+    },
+    {
+      "node_bindings": [
+        {
+          "qg_id": "a",
+          "kg_id": [
+            "MONDO:0005090"
+          ]
+        },
+        {
+          "qg_id": "b",
+          "kg_id": [
+            "MESH:D011433",
+            "CHEBI:7735",
+            "MESH:D000069470",
+            "MESH:D013881",
+            "CHEBI:10119",
+            "MESH:D013469",
+            "MESH:D005473",
+            "CHEBI:3766",
+            "MESH:D008140",
+            "CHEBI:8871"
+          ],
+          "enriched_nodes": [
+            "MONDO:0001821"
+          ],
+          "p_value": 2.1666161404028012e-27,
+          "coalescence_method": "graph_enrichment"
+        },
+        {
+          "qg_id": "extra_qn_0",
+          "kg_id": [
+            "MONDO:0001821"
+          ]
+        }
+      ],
+      "edge_bindings": [
+        {
+          "qg_id": "ab",
+          "kg_id": "d14eb3961c1f7388e1d825087793b09c",
+          "weight": 0.9952594092303608
+        },
+        {
+          "qg_id": "ab",
+          "kg_id": "0f708fa3e227b1fc99acf54b86ab0067",
+          "weight": 0.4999999999999998
+        },
+        {
+          "qg_id": "ab",
+          "kg_id": "b10e8f04da87590a3f4594b55cb5f622",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "ab",
+          "kg_id": "d614c7ce9753c9c96776b0b8c0496b90",
+          "weight": 0.4999999999999998
+        },
+        {
+          "qg_id": "ab",
+          "kg_id": "4c31cfcb4fcca8119bacadf5ff9c7c3f",
+          "weight": 0.4999999999999998
+        },
+        {
+          "qg_id": "ab",
+          "kg_id": "f35fb52da54f92f60696a99e84bfa51a",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "ab",
+          "kg_id": "4a11a33f29fdbe47355079b7f43d97d0",
+          "weight": 0.6772190444071822
+        },
+        {
+          "qg_id": "ab",
+          "kg_id": "f07c7b7ecfe8842148bd274046d16b91",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "ab",
+          "kg_id": "b59a6c9652482f7a0b9f83afc9ae4146",
+          "weight": 0.4999999999999998
+        },
+        {
+          "qg_id": "ab",
+          "kg_id": "43821d8754c5fd847b24ae5bff93cf0b",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "2975809162555465963",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "6281542558886975516",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "-5348600792812983780",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "7019854002873610823",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "8601234880450130505",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "-8847037924218056157",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "-312188439148924712",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "6301238355639971215",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "-5019115961127510681",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "3239195488415194732",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "s2",
+          "kg_id": "ac91e8d3-25b2-4a33-a705-53bb9e992169",
+          "weight": 0.0
+        },
+        {
+          "qg_id": "s5",
+          "kg_id": "1d8103c5-ec7f-4113-b748-a831f50348ec",
+          "weight": 0.35494629941051015
+        },
+        {
+          "qg_id": "s7",
+          "kg_id": "10cc973f-a2c3-425a-88fc-053d40f9d05c",
+          "weight": 0.08212742799994421
+        },
+        {
+          "qg_id": "s12",
+          "kg_id": "0ed76ed3-1ae6-4f2b-90b6-5af65e71863e",
+          "weight": 0.004461175571339071
+        },
+        {
+          "qg_id": "s28",
+          "kg_id": "d5dbfcb3-012b-4a93-b08d-7977d3227c2b",
+          "weight": 0.0476342062535382
+        },
+        {
+          "qg_id": "s31",
+          "kg_id": "04c630e7-f050-436a-bd3b-cc9ab8d370a3",
+          "weight": 0.2946421395968455
+        }
+      ],
+      "score": 6161.777856681035
+    },
+    {
+      "node_bindings": [
+        {
+          "qg_id": "a",
+          "kg_id": [
+            "MONDO:0005090"
+          ]
+        },
+        {
+          "qg_id": "b",
+          "kg_id": [
+            "MESH:C522667",
+            "CHEMBL.COMPOUND:CHEMBL2106135",
+            "CHEBI:7735",
+            "MESH:D013881",
+            "CHEBI:10119",
+            "MESH:D013469",
+            "MESH:D005473",
+            "CHEBI:3766",
+            "MESH:D008972",
+            "MESH:C007761",
+            "MESH:D000077582"
+          ],
+          "enriched_nodes": [
+            "MONDO:0003996"
+          ],
+          "p_value": 2.517258487048509e-27,
+          "coalescence_method": "graph_enrichment"
+        },
+        {
+          "qg_id": "extra_qn_0",
+          "kg_id": [
+            "MONDO:0003996"
+          ]
+        }
+      ],
+      "edge_bindings": [
+        {
+          "qg_id": "ab",
+          "kg_id": "d14eb3961c1f7388e1d825087793b09c",
+          "weight": 0.9952594092303608
+        },
+        {
+          "qg_id": "ab",
+          "kg_id": "b81fdf71694595916d701accb5b538ac",
+          "weight": 0.7999999999999998
+        },
+        {
+          "qg_id": "ab",
+          "kg_id": "faf12afc64a27e030125dd3011fcff06",
+          "weight": 0.6772190444071822
+        },
+        {
+          "qg_id": "ab",
+          "kg_id": "29805b4c97964fbcbc034e51592e1025",
+          "weight": 0.4999999999999998
+        },
+        {
+          "qg_id": "ab",
+          "kg_id": "b10e8f04da87590a3f4594b55cb5f622",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "ab",
+          "kg_id": "d614c7ce9753c9c96776b0b8c0496b90",
+          "weight": 0.4999999999999998
+        },
+        {
+          "qg_id": "ab",
+          "kg_id": "4c31cfcb4fcca8119bacadf5ff9c7c3f",
+          "weight": 0.4999999999999998
+        },
+        {
+          "qg_id": "ab",
+          "kg_id": "9b613f3b2cf64f7a0b7ca99f716d67d6",
+          "weight": 0.9996952148735141
+        },
+        {
+          "qg_id": "ab",
+          "kg_id": "f07c7b7ecfe8842148bd274046d16b91",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "ab",
+          "kg_id": "43821d8754c5fd847b24ae5bff93cf0b",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "ab",
+          "kg_id": "4e71ece190e47455f7ae8b31d80dd3a9",
+          "weight": 0.4999999999999998
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "5770792252551960458",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "-7897425296690351813",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "7741414394506304949",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "4871934331348264722",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "-2246407948511911578",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "5856721719705679373",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "-3924457529225514661",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "1731452357765047931",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "553658486186695099",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "1539859625233732984",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "-3393133581320864775",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "s5",
+          "kg_id": "1d8103c5-ec7f-4113-b748-a831f50348ec",
+          "weight": 0.35494629941051015
+        },
+        {
+          "qg_id": "s18",
+          "kg_id": "f235abe9-d66c-4777-aa7a-0b7c25a56a83",
+          "weight": 0.04000789911277636
+        },
+        {
+          "qg_id": "s20",
+          "kg_id": "c52e233d-3864-4615-afb9-6fb1103a22a9",
+          "weight": 0.07670347341815309
+        },
+        {
+          "qg_id": "s28",
+          "kg_id": "d5dbfcb3-012b-4a93-b08d-7977d3227c2b",
+          "weight": 0.0476342062535382
+        },
+        {
+          "qg_id": "s31",
+          "kg_id": "04c630e7-f050-436a-bd3b-cc9ab8d370a3",
+          "weight": 0.2946421395968455
+        },
+        {
+          "qg_id": "s37",
+          "kg_id": "a1d12a86-1869-40c0-b989-7dddb20fd3e3",
+          "weight": 0.043592053932963504
+        },
+        {
+          "qg_id": "s38",
+          "kg_id": "4c101a2b-dcd8-4ef5-833f-3bd6633e1ceb",
+          "weight": 0.25356645531326705
+        },
+        {
+          "qg_id": "s158",
+          "kg_id": "660ff200-4ef5-48df-a6f1-4733aca70a7a",
+          "weight": 0.002715323202800546
+        },
+        {
+          "qg_id": "s161",
+          "kg_id": "d310e14c-16ad-4d2f-a813-090a9284ec53",
+          "weight": 0.018193720108555578
+        },
+        {
+          "qg_id": "s163",
+          "kg_id": "bb0db942-80ee-43e7-b8d0-f333c9d55462",
+          "weight": 0.023458097583592075
+        },
+        {
+          "qg_id": "s164",
+          "kg_id": "5d3f160d-93ae-4a69-b8e8-07fbe98051df",
+          "weight": 0.01998383611456145
+        },
+        {
+          "qg_id": "s166",
+          "kg_id": "7a775aba-517d-466c-9e2c-9a745c3df915",
+          "weight": 0.003412688203599412
+        },
+        {
+          "qg_id": "s167",
+          "kg_id": "a152a6f9-b8d9-4ca3-bfa0-3afda56955fe",
+          "weight": 0.0020461087657548394
+        },
+        {
+          "qg_id": "s168",
+          "kg_id": "4785bc75-b2bc-4b56-940d-75bb932d136c",
+          "weight": 0.010884399122968125
+        }
+      ],
+      "score": 6161.777856681035
+    },
+    {
+      "node_bindings": [
+        {
+          "qg_id": "a",
+          "kg_id": [
+            "MONDO:0005090"
+          ]
+        },
+        {
+          "qg_id": "b",
+          "kg_id": [
+            "CHEBI:7735",
+            "MESH:D000069470",
+            "CHEBI:5613",
+            "MESH:D003990",
+            "MESH:D012436",
+            "CHEBI:10119",
+            "MESH:D011398",
+            "MESH:D005473",
+            "CHEBI:3766",
+            "MESH:D013881",
+            "MESH:C007761",
+            "CHEBI:8871"
+          ],
+          "enriched_nodes": [
+            "MONDO:0011728"
+          ],
+          "p_value": 3.3583123981091605e-25,
+          "coalescence_method": "graph_enrichment"
+        },
+        {
+          "qg_id": "extra_qn_0",
+          "kg_id": [
+            "MONDO:0011728"
+          ]
+        }
+      ],
+      "edge_bindings": [
+        {
+          "qg_id": "ab",
+          "kg_id": "d14eb3961c1f7388e1d825087793b09c",
+          "weight": 0.9952594092303608
+        },
+        {
+          "qg_id": "ab",
+          "kg_id": "5f9d7ec7475fcd03c7d0349c3d43ffd7",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "ab",
+          "kg_id": "faf12afc64a27e030125dd3011fcff06",
+          "weight": 0.6772190444071822
+        },
+        {
+          "qg_id": "ab",
+          "kg_id": "0f708fa3e227b1fc99acf54b86ab0067",
+          "weight": 0.4999999999999998
+        },
+        {
+          "qg_id": "ab",
+          "kg_id": "b10e8f04da87590a3f4594b55cb5f622",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "ab",
+          "kg_id": "46d04f20397875b7376435c704c3bd02",
+          "weight": 0.4999999999999998
+        },
+        {
+          "qg_id": "ab",
+          "kg_id": "b350a7cdeb917e5427a848255024e654",
+          "weight": 0.4999999999999998
+        },
+        {
+          "qg_id": "ab",
+          "kg_id": "d614c7ce9753c9c96776b0b8c0496b90",
+          "weight": 0.4999999999999998
+        },
+        {
+          "qg_id": "ab",
+          "kg_id": "f35fb52da54f92f60696a99e84bfa51a",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "ab",
+          "kg_id": "444737174a86b6215191c9ac6115486b",
+          "weight": 0.4999999999999998
+        },
+        {
+          "qg_id": "ab",
+          "kg_id": "f07c7b7ecfe8842148bd274046d16b91",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "ab",
+          "kg_id": "43821d8754c5fd847b24ae5bff93cf0b",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "6522994772687627102",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "6892156447309160349",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "-1378793720638841003",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "4646137372359683669",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "-10230626008975302",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "7827471067704430377",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "2267343042018516606",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "-5787985267163603999",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "-4924404144949975220",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "-5491944953753996282",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "848201929983221596",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "2727619992641654831",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "s9",
+          "kg_id": "6dcc0290-4a57-4641-841e-7b7bce0c4dfa",
+          "weight": 0.0043642394266718565
+        },
+        {
+          "qg_id": "s12",
+          "kg_id": "0ed76ed3-1ae6-4f2b-90b6-5af65e71863e",
+          "weight": 0.004461175571339071
+        },
+        {
+          "qg_id": "s16",
+          "kg_id": "4d694c72-5629-4e7b-9210-3feb7d892a36",
+          "weight": 0.00968624868675172
+        },
+        {
+          "qg_id": "s25",
+          "kg_id": "a782b019-3deb-4df6-8e5f-a5e00606d2bf",
+          "weight": 0.008965406293893974
+        },
+        {
+          "qg_id": "s28",
+          "kg_id": "d5dbfcb3-012b-4a93-b08d-7977d3227c2b",
+          "weight": 0.0476342062535382
+        },
+        {
+          "qg_id": "s31",
+          "kg_id": "04c630e7-f050-436a-bd3b-cc9ab8d370a3",
+          "weight": 0.2946421395968455
+        },
+        {
+          "qg_id": "s37",
+          "kg_id": "a1d12a86-1869-40c0-b989-7dddb20fd3e3",
+          "weight": 0.043592053932963504
+        },
+        {
+          "qg_id": "s171",
+          "kg_id": "a959bea0-130e-4870-a33c-35589dc69120",
+          "weight": 0.0005524300448616071
+        },
+        {
+          "qg_id": "s177",
+          "kg_id": "7d3517f9-a270-4342-856c-1757ab9f050b",
+          "weight": 0.0008948176945193786
+        },
+        {
+          "qg_id": "s179",
+          "kg_id": "0548276d-4ee0-4d87-8f6f-c96101c81d2e",
+          "weight": 0.000560179693601004
+        }
+      ],
+      "score": 6161.777856681035
+    },
+    {
+      "node_bindings": [
+        {
+          "qg_id": "a",
+          "kg_id": [
+            "MONDO:0005090"
+          ]
+        },
+        {
+          "qg_id": "b",
+          "kg_id": [
+            "CHEBI:7735",
+            "MESH:D000069470",
+            "CHEBI:5613",
+            "MESH:D003990",
+            "MESH:D012436",
+            "CHEBI:10119",
+            "CHEBI:3766",
+            "MESH:D013881",
+            "MESH:C007761",
+            "CHEBI:8871"
+          ],
+          "enriched_nodes": [
+            "HP:0005986"
+          ],
+          "p_value": 4.0032943803906593e-25,
+          "coalescence_method": "graph_enrichment"
+        },
+        {
+          "qg_id": "extra_qn_0",
+          "kg_id": [
+            "HP:0005986"
+          ]
+        }
+      ],
+      "edge_bindings": [
+        {
+          "qg_id": "ab",
+          "kg_id": "d14eb3961c1f7388e1d825087793b09c",
+          "weight": 0.9952594092303608
+        },
+        {
+          "qg_id": "ab",
+          "kg_id": "5f9d7ec7475fcd03c7d0349c3d43ffd7",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "ab",
+          "kg_id": "faf12afc64a27e030125dd3011fcff06",
+          "weight": 0.6772190444071822
+        },
+        {
+          "qg_id": "ab",
+          "kg_id": "0f708fa3e227b1fc99acf54b86ab0067",
+          "weight": 0.4999999999999998
+        },
+        {
+          "qg_id": "ab",
+          "kg_id": "b10e8f04da87590a3f4594b55cb5f622",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "ab",
+          "kg_id": "46d04f20397875b7376435c704c3bd02",
+          "weight": 0.4999999999999998
+        },
+        {
+          "qg_id": "ab",
+          "kg_id": "b350a7cdeb917e5427a848255024e654",
+          "weight": 0.4999999999999998
+        },
+        {
+          "qg_id": "ab",
+          "kg_id": "f35fb52da54f92f60696a99e84bfa51a",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "ab",
+          "kg_id": "f07c7b7ecfe8842148bd274046d16b91",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "ab",
+          "kg_id": "43821d8754c5fd847b24ae5bff93cf0b",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "-5314436861094858659",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "9109175573202151279",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "8068497052082100618",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "7637025660016775715",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "-2027718343702037304",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "1605542730135855531",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "-3870493768894112148",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "-1074031873393960166",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "8154983881750916768",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "-5458939759379515416",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "s9",
+          "kg_id": "6dcc0290-4a57-4641-841e-7b7bce0c4dfa",
+          "weight": 0.0043642394266718565
+        },
+        {
+          "qg_id": "s12",
+          "kg_id": "0ed76ed3-1ae6-4f2b-90b6-5af65e71863e",
+          "weight": 0.004461175571339071
+        },
+        {
+          "qg_id": "s16",
+          "kg_id": "4d694c72-5629-4e7b-9210-3feb7d892a36",
+          "weight": 0.00968624868675172
+        },
+        {
+          "qg_id": "s31",
+          "kg_id": "04c630e7-f050-436a-bd3b-cc9ab8d370a3",
+          "weight": 0.2946421395968455
+        },
+        {
+          "qg_id": "s37",
+          "kg_id": "a1d12a86-1869-40c0-b989-7dddb20fd3e3",
+          "weight": 0.043592053932963504
+        },
+        {
+          "qg_id": "s182",
+          "kg_id": "874d5c25-3f07-4506-9590-75bdac33dd00",
+          "weight": 0.12217618045596934
+        },
+        {
+          "qg_id": "s184",
+          "kg_id": "e30559f0-6722-42ca-b3df-8dee74998573",
+          "weight": 0.0039486274814559685
+        },
+        {
+          "qg_id": "s186",
+          "kg_id": "792df59f-0c72-4ab1-80f3-91c6d14e1f94",
+          "weight": 0.000360036274363873
+        },
+        {
+          "qg_id": "s187",
+          "kg_id": "d8f65c5e-2690-446f-9751-742fa86ea89c",
+          "weight": 0.004230999952927084
+        },
+        {
+          "qg_id": "s190",
+          "kg_id": "b2f546bd-8ce6-4a9a-b8a4-96f11f4decc5",
+          "weight": 0.005411044124526976
+        },
+        {
+          "qg_id": "s191",
+          "kg_id": "bd755fca-bf56-4d16-abdc-734f4d464d34",
+          "weight": 0.0006282019817778206
+        }
+      ],
+      "score": 6161.777856681035
+    },
+    {
+      "node_bindings": [
+        {
+          "qg_id": "a",
+          "kg_id": [
+            "MONDO:0005090"
+          ]
+        },
+        {
+          "qg_id": "b",
+          "kg_id": [
+            "CHEBI:8707",
+            "CHEBI:7735",
+            "CHEBI:5613",
+            "CHEBI:31236",
+            "CHEBI:65173",
+            "CHEBI:10119",
+            "CHEBI:3766",
+            "CHEBI:70735",
+            "CHEBI:8871"
+          ],
+          "enriched_nodes": [
+            "MONDO:0010096"
+          ],
+          "p_value": 1.0639689920686447e-24,
+          "coalescence_method": "graph_enrichment"
+        },
+        {
+          "qg_id": "extra_qn_0",
+          "kg_id": [
+            "MONDO:0010096"
+          ]
+        }
+      ],
+      "edge_bindings": [
+        {
+          "qg_id": "ab",
+          "kg_id": "14403bd92938ce4daec86a4771bf62e5",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "ab",
+          "kg_id": "5f9d7ec7475fcd03c7d0349c3d43ffd7",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "ab",
+          "kg_id": "1f6d1af9c9790d9e764acbcefa529560",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "ab",
+          "kg_id": "b10e8f04da87590a3f4594b55cb5f622",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "ab",
+          "kg_id": "25ca4674bccf3d3623ec99ddd401fef8",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "ab",
+          "kg_id": "f35fb52da54f92f60696a99e84bfa51a",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "ab",
+          "kg_id": "f07c7b7ecfe8842148bd274046d16b91",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "ab",
+          "kg_id": "45bb9997c8ac47225836c8e74cf91b5a",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "ab",
+          "kg_id": "43821d8754c5fd847b24ae5bff93cf0b",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "3313394613794454479",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "-7517994081457988447",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "-6632089769227922151",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "-5376353285230522037",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "3087435688090461204",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "-2846440941249737967",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "2548681795836610915",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "4502297031710166852",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "-3228930265803780121",
+          "weight": 0.2679491924311228
+        }
+      ],
+      "score": 109.10848778735631
+    },
+    {
+      "node_bindings": [
+        {
+          "qg_id": "a",
+          "kg_id": [
+            "MONDO:0005090"
+          ]
+        },
+        {
+          "qg_id": "b",
+          "kg_id": [
+            "CHEBI:7735",
+            "CHEBI:5613",
+            "CHEBI:31236",
+            "MESH:D013881",
+            "CHEBI:10119",
+            "MESH:D008653",
+            "MESH:D005473",
+            "CHEBI:3766",
+            "MESH:D008140",
+            "MESH:D000077582",
+            "CHEBI:8871"
+          ],
+          "enriched_nodes": [
+            "MONDO:0002442"
+          ],
+          "p_value": 1.1345698845168233e-24,
+          "coalescence_method": "graph_enrichment"
+        },
+        {
+          "qg_id": "extra_qn_0",
+          "kg_id": [
+            "MONDO:0002442"
+          ]
+        }
+      ],
+      "edge_bindings": [
+        {
+          "qg_id": "ab",
+          "kg_id": "d14eb3961c1f7388e1d825087793b09c",
+          "weight": 0.9952594092303608
+        },
+        {
+          "qg_id": "ab",
+          "kg_id": "5f9d7ec7475fcd03c7d0349c3d43ffd7",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "ab",
+          "kg_id": "b10e8f04da87590a3f4594b55cb5f622",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "ab",
+          "kg_id": "d614c7ce9753c9c96776b0b8c0496b90",
+          "weight": 0.4999999999999998
+        },
+        {
+          "qg_id": "ab",
+          "kg_id": "f35fb52da54f92f60696a99e84bfa51a",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "ab",
+          "kg_id": "9b613f3b2cf64f7a0b7ca99f716d67d6",
+          "weight": 0.9996952148735141
+        },
+        {
+          "qg_id": "ab",
+          "kg_id": "4a11a33f29fdbe47355079b7f43d97d0",
+          "weight": 0.6772190444071822
+        },
+        {
+          "qg_id": "ab",
+          "kg_id": "8efc24e375e9f21c0dcabd50d9df36e2",
+          "weight": 0.4999999999999998
+        },
+        {
+          "qg_id": "ab",
+          "kg_id": "f07c7b7ecfe8842148bd274046d16b91",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "ab",
+          "kg_id": "45bb9997c8ac47225836c8e74cf91b5a",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "ab",
+          "kg_id": "43821d8754c5fd847b24ae5bff93cf0b",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "-6672409449485326295",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "-6827050753397046369",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "6861170717065171877",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "-753426095348810382",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "-1587247218753308308",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "7080295629003475718",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "7405594811679801021",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "2767569132135140807",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "-3677426254751171665",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "-5574806182870017535",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "6589477666846826678",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "s7",
+          "kg_id": "10cc973f-a2c3-425a-88fc-053d40f9d05c",
+          "weight": 0.08212742799994421
+        },
+        {
+          "qg_id": "s26",
+          "kg_id": "33f47eee-3df3-44e6-a794-6c0afb0c5e5b",
+          "weight": 0.021531300514223473
+        },
+        {
+          "qg_id": "s28",
+          "kg_id": "d5dbfcb3-012b-4a93-b08d-7977d3227c2b",
+          "weight": 0.0476342062535382
+        },
+        {
+          "qg_id": "s31",
+          "kg_id": "04c630e7-f050-436a-bd3b-cc9ab8d370a3",
+          "weight": 0.2946421395968455
+        },
+        {
+          "qg_id": "s38",
+          "kg_id": "4c101a2b-dcd8-4ef5-833f-3bd6633e1ceb",
+          "weight": 0.25356645531326705
+        },
+        {
+          "qg_id": "s207",
+          "kg_id": "7ef4e325-d5b4-48d1-9094-79686fcbde54",
+          "weight": 0.0159618632355345
+        },
+        {
+          "qg_id": "s209",
+          "kg_id": "7efc05fc-dbf7-46cf-8877-bc6bd7b0217a",
+          "weight": 0.002718610432491886
+        },
+        {
+          "qg_id": "s210",
+          "kg_id": "a9012faf-fa3b-446f-a2d3-f820afeb64e5",
+          "weight": 0.011779901870920595
+        },
+        {
+          "qg_id": "s212",
+          "kg_id": "994eefd4-6d11-4aa8-9e5d-19929c722dc8",
+          "weight": 0.0035013212619530165
+        },
+        {
+          "qg_id": "s213",
+          "kg_id": "d3adc1a6-5d19-4918-9871-5146ef0132e6",
+          "weight": 0.006027404827205984
+        }
+      ],
+      "score": 6161.777856681035
+    },
+    {
+      "node_bindings": [
+        {
+          "qg_id": "a",
+          "kg_id": [
+            "MONDO:0005090"
+          ]
+        },
+        {
+          "qg_id": "b",
+          "kg_id": [
+            "CHEBI:10119",
+            "CHEBI:8707",
+            "CHEBI:7735",
+            "CHEBI:3766",
+            "CHEBI:5613",
+            "CHEBI:31236",
+            "CHEBI:8871"
+          ],
+          "enriched_nodes": [
+            "NCBIGene:3005"
+          ],
+          "p_value": 1.5464528936461813e-24,
+          "coalescence_method": "graph_enrichment"
+        },
+        {
+          "qg_id": "extra_qn_0",
+          "kg_id": [
+            "NCBIGene:3005"
+          ]
+        }
+      ],
+      "edge_bindings": [
+        {
+          "qg_id": "ab",
+          "kg_id": "14403bd92938ce4daec86a4771bf62e5",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "ab",
+          "kg_id": "5f9d7ec7475fcd03c7d0349c3d43ffd7",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "ab",
+          "kg_id": "45bb9997c8ac47225836c8e74cf91b5a",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "ab",
+          "kg_id": "f07c7b7ecfe8842148bd274046d16b91",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "ab",
+          "kg_id": "b10e8f04da87590a3f4594b55cb5f622",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "ab",
+          "kg_id": "43821d8754c5fd847b24ae5bff93cf0b",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "ab",
+          "kg_id": "f35fb52da54f92f60696a99e84bfa51a",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "2903477335087171128",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "6904698504564010150",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "-2591066488505739969",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "6598173366866798268",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "4999754743720440144",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "185545632135368478",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "-4419708991396102602",
+          "weight": 0.2679491924311228
+        }
+      ],
+      "score": 1437.196623922414
+    },
+    {
+      "node_bindings": [
+        {
+          "qg_id": "a",
+          "kg_id": [
+            "MONDO:0005090"
+          ]
+        },
+        {
+          "qg_id": "b",
+          "kg_id": [
+            "CHEBI:8707",
+            "CHEBI:7735",
+            "CHEBI:5613",
+            "CHEBI:31236",
+            "CHEBI:65173",
+            "CHEBI:10119",
+            "CHEBI:3766",
+            "CHEBI:70735",
+            "CHEBI:8871"
+          ],
+          "enriched_nodes": [
+            "MONDO:0004745"
+          ],
+          "p_value": 2.2175852221653953e-24,
+          "coalescence_method": "graph_enrichment"
+        },
+        {
+          "qg_id": "extra_qn_0",
+          "kg_id": [
+            "MONDO:0004745"
+          ]
+        }
+      ],
+      "edge_bindings": [
+        {
+          "qg_id": "ab",
+          "kg_id": "14403bd92938ce4daec86a4771bf62e5",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "ab",
+          "kg_id": "5f9d7ec7475fcd03c7d0349c3d43ffd7",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "ab",
+          "kg_id": "1f6d1af9c9790d9e764acbcefa529560",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "ab",
+          "kg_id": "b10e8f04da87590a3f4594b55cb5f622",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "ab",
+          "kg_id": "25ca4674bccf3d3623ec99ddd401fef8",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "ab",
+          "kg_id": "f35fb52da54f92f60696a99e84bfa51a",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "ab",
+          "kg_id": "f07c7b7ecfe8842148bd274046d16b91",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "ab",
+          "kg_id": "45bb9997c8ac47225836c8e74cf91b5a",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "ab",
+          "kg_id": "43821d8754c5fd847b24ae5bff93cf0b",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "-1962044768136291229",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "-1005251232936558216",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "-3284564226623813878",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "-4872118121976529156",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "-4648464691848319088",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "-8823903150151534828",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "-8156495696967329638",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "3561452259725721186",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "-5659376266817130189",
+          "weight": 0.2679491924311228
+        }
+      ],
+      "score": 109.10848778735631
+    },
+    {
+      "node_bindings": [
+        {
+          "qg_id": "a",
+          "kg_id": [
+            "MONDO:0005090"
+          ]
+        },
+        {
+          "qg_id": "b",
+          "kg_id": [
+            "MESH:D011433",
+            "CHEBI:7735",
+            "MESH:D000069470",
+            "CHEBI:5613",
+            "CHEBI:31236",
+            "MESH:C515050",
+            "MESH:D013881",
+            "MESH:D012906",
+            "MESH:D005473",
+            "CHEBI:3766",
+            "MESH:D008140",
+            "CHEBI:8871"
+          ],
+          "enriched_nodes": [
+            "MONDO:0001442"
+          ],
+          "p_value": 2.5734817391278455e-24,
+          "coalescence_method": "graph_enrichment"
+        },
+        {
+          "qg_id": "extra_qn_0",
+          "kg_id": [
+            "MONDO:0001442"
+          ]
+        }
+      ],
+      "edge_bindings": [
+        {
+          "qg_id": "ab",
+          "kg_id": "d14eb3961c1f7388e1d825087793b09c",
+          "weight": 0.9952594092303608
+        },
+        {
+          "qg_id": "ab",
+          "kg_id": "5f9d7ec7475fcd03c7d0349c3d43ffd7",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "ab",
+          "kg_id": "0f708fa3e227b1fc99acf54b86ab0067",
+          "weight": 0.4999999999999998
+        },
+        {
+          "qg_id": "ab",
+          "kg_id": "b10e8f04da87590a3f4594b55cb5f622",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "ab",
+          "kg_id": "d614c7ce9753c9c96776b0b8c0496b90",
+          "weight": 0.4999999999999998
+        },
+        {
+          "qg_id": "ab",
+          "kg_id": "f35fb52da54f92f60696a99e84bfa51a",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "ab",
+          "kg_id": "ecd1e07e353f9416c93c3e9b5e098d77",
+          "weight": 0.4999999999999998
+        },
+        {
+          "qg_id": "ab",
+          "kg_id": "4a11a33f29fdbe47355079b7f43d97d0",
+          "weight": 0.6772190444071822
+        },
+        {
+          "qg_id": "ab",
+          "kg_id": "f07c7b7ecfe8842148bd274046d16b91",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "ab",
+          "kg_id": "45bb9997c8ac47225836c8e74cf91b5a",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "ab",
+          "kg_id": "b59a6c9652482f7a0b9f83afc9ae4146",
+          "weight": 0.4999999999999998
+        },
+        {
+          "qg_id": "ab",
+          "kg_id": "477e260e9fd1ccd91159dbe57337c22e",
+          "weight": 0.4999999999999998
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "5690703065649472826",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "5460400504505329543",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "4344434931242275518",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "6553784974715878521",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "-7048218732797866375",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "3111485969520759884",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "-4779071809644295298",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "4052060478951709525",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "-8525235098658116318",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "-1588948501470902522",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "-7716233646038627236",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "1097019692333158494",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "s2",
+          "kg_id": "ac91e8d3-25b2-4a33-a705-53bb9e992169",
+          "weight": 0.0
+        },
+        {
+          "qg_id": "s7",
+          "kg_id": "10cc973f-a2c3-425a-88fc-053d40f9d05c",
+          "weight": 0.08212742799994421
+        },
+        {
+          "qg_id": "s12",
+          "kg_id": "0ed76ed3-1ae6-4f2b-90b6-5af65e71863e",
+          "weight": 0.004461175571339071
+        },
+        {
+          "qg_id": "s27",
+          "kg_id": "9392cd8f-8cf6-465a-bb1f-5af5a9db2690",
+          "weight": 0.0
+        },
+        {
+          "qg_id": "s28",
+          "kg_id": "d5dbfcb3-012b-4a93-b08d-7977d3227c2b",
+          "weight": 0.0476342062535382
+        },
+        {
+          "qg_id": "s31",
+          "kg_id": "04c630e7-f050-436a-bd3b-cc9ab8d370a3",
+          "weight": 0.2946421395968455
+        },
+        {
+          "qg_id": "s35",
+          "kg_id": "90b99036-281c-47a0-af2e-22722581baf5",
+          "weight": 0.002457651043953346
+        },
+        {
+          "qg_id": "s234",
+          "kg_id": "5c76198d-90e9-4ae2-a4c2-4d4aef97f9a2",
+          "weight": 0.0
+        },
+        {
+          "qg_id": "s236",
+          "kg_id": "9d777176-179b-496c-8594-003803f761f2",
+          "weight": 0.01765281086442294
+        },
+        {
+          "qg_id": "s239",
+          "kg_id": "d88cc98f-fcd7-41a4-9542-b77f7bc0cc9b",
+          "weight": 0.0006325139543741365
+        },
+        {
+          "qg_id": "s242",
+          "kg_id": "f91db030-24bb-4579-85e9-ede16ee1c071",
+          "weight": 0.033613768904860564
+        }
+      ],
+      "score": 6161.777856681035
+    },
+    {
+      "node_bindings": [
+        {
+          "qg_id": "a",
+          "kg_id": [
+            "MONDO:0005090"
+          ]
+        },
+        {
+          "qg_id": "b",
+          "kg_id": [
+            "CHEBI:8707",
+            "CHEBI:7735",
+            "CHEBI:5613",
+            "CHEBI:31236",
+            "CHEBI:65173",
+            "CHEBI:10119",
+            "CHEBI:3766",
+            "CHEBI:70735",
+            "CHEBI:8871"
+          ],
+          "enriched_nodes": [
+            "MONDO:0019790"
+          ],
+          "p_value": 5.1412246973933096e-24,
+          "coalescence_method": "graph_enrichment"
+        },
+        {
+          "qg_id": "extra_qn_0",
+          "kg_id": [
+            "MONDO:0019790"
+          ]
+        }
+      ],
+      "edge_bindings": [
+        {
+          "qg_id": "ab",
+          "kg_id": "14403bd92938ce4daec86a4771bf62e5",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "ab",
+          "kg_id": "5f9d7ec7475fcd03c7d0349c3d43ffd7",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "ab",
+          "kg_id": "1f6d1af9c9790d9e764acbcefa529560",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "ab",
+          "kg_id": "b10e8f04da87590a3f4594b55cb5f622",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "ab",
+          "kg_id": "25ca4674bccf3d3623ec99ddd401fef8",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "ab",
+          "kg_id": "f35fb52da54f92f60696a99e84bfa51a",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "ab",
+          "kg_id": "f07c7b7ecfe8842148bd274046d16b91",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "ab",
+          "kg_id": "45bb9997c8ac47225836c8e74cf91b5a",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "ab",
+          "kg_id": "43821d8754c5fd847b24ae5bff93cf0b",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "7740549283932957956",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "-2172570163715538074",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "-5968710425447150612",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "2542756441822673782",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "789211166546123808",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "-5202001598824284145",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "3932779916271202568",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "6336138413476724206",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "3423002498120100671",
+          "weight": 0.2679491924311228
+        }
+      ],
+      "score": 109.10848778735631
+    },
+    {
+      "node_bindings": [
+        {
+          "qg_id": "a",
+          "kg_id": [
+            "MONDO:0005090"
+          ]
+        },
+        {
+          "qg_id": "b",
+          "kg_id": [
+            "CHEBI:10119",
+            "MESH:D013469",
+            "CHEBI:7735",
+            "CHEBI:3766",
+            "MESH:D013881",
+            "CHEBI:5613",
+            "CHEBI:31236",
+            "MESH:D000077582"
+          ],
+          "enriched_nodes": [
+            "MONDO:0001484"
+          ],
+          "p_value": 6.840868480583815e-24,
+          "coalescence_method": "graph_enrichment"
+        },
+        {
+          "qg_id": "extra_qn_0",
+          "kg_id": [
+            "MONDO:0001484"
+          ]
+        }
+      ],
+      "edge_bindings": [
+        {
+          "qg_id": "ab",
+          "kg_id": "d14eb3961c1f7388e1d825087793b09c",
+          "weight": 0.9952594092303608
+        },
+        {
+          "qg_id": "ab",
+          "kg_id": "5f9d7ec7475fcd03c7d0349c3d43ffd7",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "ab",
+          "kg_id": "9b613f3b2cf64f7a0b7ca99f716d67d6",
+          "weight": 0.9996952148735141
+        },
+        {
+          "qg_id": "ab",
+          "kg_id": "b10e8f04da87590a3f4594b55cb5f622",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "ab",
+          "kg_id": "f07c7b7ecfe8842148bd274046d16b91",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "ab",
+          "kg_id": "45bb9997c8ac47225836c8e74cf91b5a",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "ab",
+          "kg_id": "43821d8754c5fd847b24ae5bff93cf0b",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "ab",
+          "kg_id": "4c31cfcb4fcca8119bacadf5ff9c7c3f",
+          "weight": 0.4999999999999998
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "-6510810324898532403",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "2880476554265696256",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "-3781630710503599698",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "-2096299938036046806",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "-6246089208031066512",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "809868953028379858",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "-2965480311127690162",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "7074869925656453683",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "s5",
+          "kg_id": "1d8103c5-ec7f-4113-b748-a831f50348ec",
+          "weight": 0.35494629941051015
+        },
+        {
+          "qg_id": "s31",
+          "kg_id": "04c630e7-f050-436a-bd3b-cc9ab8d370a3",
+          "weight": 0.2946421395968455
+        },
+        {
+          "qg_id": "s38",
+          "kg_id": "4c101a2b-dcd8-4ef5-833f-3bd6633e1ceb",
+          "weight": 0.25356645531326705
+        },
+        {
+          "qg_id": "s250",
+          "kg_id": "1bb70847-c052-482e-9b9b-7eaffd9b3736",
+          "weight": 0.0
+        },
+        {
+          "qg_id": "s252",
+          "kg_id": "823e078a-05fa-4ebd-b9ec-352e1b063e55",
+          "weight": 0.020825181476084698
+        },
+        {
+          "qg_id": "s255",
+          "kg_id": "398a62b3-2808-4ebf-ba56-1a3b2e753f10",
+          "weight": 0.019634160274862866
+        },
+        {
+          "qg_id": "s258",
+          "kg_id": "99f17418-53d2-4eaa-8813-8c929d7b5b5b",
+          "weight": 0.018455662198955336
+        }
+      ],
+      "score": 6161.777856681035
+    },
+    {
+      "node_bindings": [
+        {
+          "qg_id": "a",
+          "kg_id": [
+            "MONDO:0005090"
+          ]
+        },
+        {
+          "qg_id": "b",
+          "kg_id": [
+            "MESH:D014282",
+            "MESH:D000069470",
+            "CHEBI:31236",
+            "CHEBI:10119",
+            "MESH:D013469",
+            "CHEBI:3766",
+            "MESH:D013881",
+            "MESH:D008972",
+            "MESH:D000077582"
+          ],
+          "enriched_nodes": [
+            "MONDO:0002025"
+          ],
+          "p_value": 8.218977911912807e-24,
+          "coalescence_method": "graph_enrichment"
+        },
+        {
+          "qg_id": "extra_qn_0",
+          "kg_id": [
+            "MONDO:0002025"
+          ]
+        }
+      ],
+      "edge_bindings": [
+        {
+          "qg_id": "ab",
+          "kg_id": "d14eb3961c1f7388e1d825087793b09c",
+          "weight": 0.9952594092303608
+        },
+        {
+          "qg_id": "ab",
+          "kg_id": "b81fdf71694595916d701accb5b538ac",
+          "weight": 0.7999999999999998
+        },
+        {
+          "qg_id": "ab",
+          "kg_id": "0f708fa3e227b1fc99acf54b86ab0067",
+          "weight": 0.4999999999999998
+        },
+        {
+          "qg_id": "ab",
+          "kg_id": "4c31cfcb4fcca8119bacadf5ff9c7c3f",
+          "weight": 0.4999999999999998
+        },
+        {
+          "qg_id": "ab",
+          "kg_id": "9b613f3b2cf64f7a0b7ca99f716d67d6",
+          "weight": 0.9996952148735141
+        },
+        {
+          "qg_id": "ab",
+          "kg_id": "f07c7b7ecfe8842148bd274046d16b91",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "ab",
+          "kg_id": "45bb9997c8ac47225836c8e74cf91b5a",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "ab",
+          "kg_id": "43821d8754c5fd847b24ae5bff93cf0b",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "ab",
+          "kg_id": "ead0c39f0b111e2554d42e09c6639da7",
+          "weight": 0.6772190444071822
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "-3692759765335553882",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "3515930600984585296",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "7278140728218197362",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "6044889957541981138",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "-8368178927942799853",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "-7655276960712430642",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "5640599220312391597",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "4661912403617054766",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "-2947888501328286768",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "s5",
+          "kg_id": "1d8103c5-ec7f-4113-b748-a831f50348ec",
+          "weight": 0.35494629941051015
+        },
+        {
+          "qg_id": "s12",
+          "kg_id": "0ed76ed3-1ae6-4f2b-90b6-5af65e71863e",
+          "weight": 0.004461175571339071
+        },
+        {
+          "qg_id": "s18",
+          "kg_id": "f235abe9-d66c-4777-aa7a-0b7c25a56a83",
+          "weight": 0.04000789911277636
+        },
+        {
+          "qg_id": "s31",
+          "kg_id": "04c630e7-f050-436a-bd3b-cc9ab8d370a3",
+          "weight": 0.2946421395968455
+        },
+        {
+          "qg_id": "s36",
+          "kg_id": "ad82daf4-f7d4-4b7a-ab61-a6521ac60cac",
+          "weight": 0.07502710580926264
+        },
+        {
+          "qg_id": "s38",
+          "kg_id": "4c101a2b-dcd8-4ef5-833f-3bd6633e1ceb",
+          "weight": 0.25356645531326705
+        },
+        {
+          "qg_id": "s259",
+          "kg_id": "a92df2d1-ba65-4a63-bbb5-b621afb70d34",
+          "weight": 0.0
+        },
+        {
+          "qg_id": "s260",
+          "kg_id": "a93f51b2-2c79-450a-bed5-44a9e97de625",
+          "weight": 0.01254103205807544
+        },
+        {
+          "qg_id": "s261",
+          "kg_id": "d137ff43-f140-46c8-80df-5de110061c05",
+          "weight": 0.07445389608118358
+        },
+        {
+          "qg_id": "s264",
+          "kg_id": "1fdf7e1d-a3c0-4d99-9117-f0444c1512bb",
+          "weight": 0.0285523459747139
+        },
+        {
+          "qg_id": "s266",
+          "kg_id": "1bad7a2b-9176-4c4b-83c8-35684f597c4d",
+          "weight": 0.14513022511504015
+        },
+        {
+          "qg_id": "s267",
+          "kg_id": "28983c69-3f4a-4459-8705-d04e36a3705f",
+          "weight": 0.003982626437029957
+        },
+        {
+          "qg_id": "s268",
+          "kg_id": "85081a49-7155-4b80-beb6-8c1eceae2977",
+          "weight": 0.017892326681206105
+        }
+      ],
+      "score": 6161.777856681035
+    },
+    {
+      "node_bindings": [
+        {
+          "qg_id": "a",
+          "kg_id": [
+            "MONDO:0005090"
+          ]
+        },
+        {
+          "qg_id": "b",
+          "kg_id": [
+            "MESH:D011433",
+            "MESH:D000069470",
+            "CHEBI:31236",
+            "CHEBI:10119",
+            "MESH:D008653",
+            "MESH:D013469",
+            "MESH:D005473",
+            "MESH:D013881",
+            "MESH:D003990",
+            "CHEBI:8871"
+          ],
+          "enriched_nodes": [
+            "MONDO:0016058"
+          ],
+          "p_value": 1.9605114872049457e-23,
+          "coalescence_method": "graph_enrichment"
+        },
+        {
+          "qg_id": "extra_qn_0",
+          "kg_id": [
+            "MONDO:0016058"
+          ]
+        }
+      ],
+      "edge_bindings": [
+        {
+          "qg_id": "ab",
+          "kg_id": "d14eb3961c1f7388e1d825087793b09c",
+          "weight": 0.9952594092303608
+        },
+        {
+          "qg_id": "ab",
+          "kg_id": "0f708fa3e227b1fc99acf54b86ab0067",
+          "weight": 0.4999999999999998
+        },
+        {
+          "qg_id": "ab",
+          "kg_id": "b350a7cdeb917e5427a848255024e654",
+          "weight": 0.4999999999999998
+        },
+        {
+          "qg_id": "ab",
+          "kg_id": "d614c7ce9753c9c96776b0b8c0496b90",
+          "weight": 0.4999999999999998
+        },
+        {
+          "qg_id": "ab",
+          "kg_id": "4c31cfcb4fcca8119bacadf5ff9c7c3f",
+          "weight": 0.4999999999999998
+        },
+        {
+          "qg_id": "ab",
+          "kg_id": "f35fb52da54f92f60696a99e84bfa51a",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "ab",
+          "kg_id": "8efc24e375e9f21c0dcabd50d9df36e2",
+          "weight": 0.4999999999999998
+        },
+        {
+          "qg_id": "ab",
+          "kg_id": "b59a6c9652482f7a0b9f83afc9ae4146",
+          "weight": 0.4999999999999998
+        },
+        {
+          "qg_id": "ab",
+          "kg_id": "45bb9997c8ac47225836c8e74cf91b5a",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "ab",
+          "kg_id": "43821d8754c5fd847b24ae5bff93cf0b",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "4027528061697825197",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "-5085644706264843047",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "-8977202683983903282",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "5068254169295547258",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "7566878842991780245",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "654521146691683263",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "-7575310183856325831",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "-1581191021484012398",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "-5866291005977195746",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "-8545993847183275955",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "s2",
+          "kg_id": "ac91e8d3-25b2-4a33-a705-53bb9e992169",
+          "weight": 0.0
+        },
+        {
+          "qg_id": "s5",
+          "kg_id": "1d8103c5-ec7f-4113-b748-a831f50348ec",
+          "weight": 0.35494629941051015
+        },
+        {
+          "qg_id": "s9",
+          "kg_id": "6dcc0290-4a57-4641-841e-7b7bce0c4dfa",
+          "weight": 0.0043642394266718565
+        },
+        {
+          "qg_id": "s12",
+          "kg_id": "0ed76ed3-1ae6-4f2b-90b6-5af65e71863e",
+          "weight": 0.004461175571339071
+        },
+        {
+          "qg_id": "s26",
+          "kg_id": "33f47eee-3df3-44e6-a794-6c0afb0c5e5b",
+          "weight": 0.021531300514223473
+        },
+        {
+          "qg_id": "s28",
+          "kg_id": "d5dbfcb3-012b-4a93-b08d-7977d3227c2b",
+          "weight": 0.0476342062535382
+        },
+        {
+          "qg_id": "s31",
+          "kg_id": "04c630e7-f050-436a-bd3b-cc9ab8d370a3",
+          "weight": 0.2946421395968455
+        },
+        {
+          "qg_id": "s276",
+          "kg_id": "e532e180-58d8-4a64-9683-9aab9c897b43",
+          "weight": 0.0006391631900974915
+        }
+      ],
+      "score": 913.1693369252874
+    },
+    {
+      "node_bindings": [
+        {
+          "qg_id": "a",
+          "kg_id": [
+            "MONDO:0005090"
+          ]
+        },
+        {
+          "qg_id": "b",
+          "kg_id": [
+            "CHEBI:10119",
+            "CHEBI:8707",
+            "CHEBI:7735",
+            "CHEBI:3766",
+            "CHEBI:5613",
+            "CHEBI:31236",
+            "CHEBI:65173",
+            "CHEBI:8871"
+          ],
+          "enriched_nodes": [
+            "UMLS:C3665587"
+          ],
+          "p_value": 1.0078501509060919e-22,
+          "coalescence_method": "graph_enrichment"
+        },
+        {
+          "qg_id": "extra_qn_0",
+          "kg_id": [
+            "UMLS:C3665587"
+          ]
+        }
+      ],
+      "edge_bindings": [
+        {
+          "qg_id": "ab",
+          "kg_id": "14403bd92938ce4daec86a4771bf62e5",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "ab",
+          "kg_id": "5f9d7ec7475fcd03c7d0349c3d43ffd7",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "ab",
+          "kg_id": "1f6d1af9c9790d9e764acbcefa529560",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "ab",
+          "kg_id": "45bb9997c8ac47225836c8e74cf91b5a",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "ab",
+          "kg_id": "f07c7b7ecfe8842148bd274046d16b91",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "ab",
+          "kg_id": "b10e8f04da87590a3f4594b55cb5f622",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "ab",
+          "kg_id": "43821d8754c5fd847b24ae5bff93cf0b",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "ab",
+          "kg_id": "f35fb52da54f92f60696a99e84bfa51a",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "-1416976046145964002",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "-4820168873422319684",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "-75826078698022543",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "6179718538818516794",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "-8941691008586318046",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "-4181854567561921948",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "-1255268251096207807",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "-8709203226392645004",
+          "weight": 0.2679491924311228
+        }
+      ],
+      "score": 109.10848778735631
+    },
+    {
+      "node_bindings": [
+        {
+          "qg_id": "a",
+          "kg_id": [
+            "MONDO:0005090"
+          ]
+        },
+        {
+          "qg_id": "b",
+          "kg_id": [
+            "CHEBI:5613",
+            "CHEBI:10119",
+            "MESH:D011398",
+            "MESH:D008653",
+            "MESH:D013469",
+            "MESH:D005473",
+            "MESH:D013881",
+            "MESH:D014282",
+            "MESH:D000077582",
+            "CHEBI:8871"
+          ],
+          "enriched_nodes": [
+            "MONDO:0005478"
+          ],
+          "p_value": 1.0315858153176445e-22,
+          "coalescence_method": "graph_enrichment"
+        },
+        {
+          "qg_id": "extra_qn_0",
+          "kg_id": [
+            "MONDO:0005478"
+          ]
+        }
+      ],
+      "edge_bindings": [
+        {
+          "qg_id": "ab",
+          "kg_id": "d14eb3961c1f7388e1d825087793b09c",
+          "weight": 0.9952594092303608
+        },
+        {
+          "qg_id": "ab",
+          "kg_id": "5f9d7ec7475fcd03c7d0349c3d43ffd7",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "ab",
+          "kg_id": "d614c7ce9753c9c96776b0b8c0496b90",
+          "weight": 0.4999999999999998
+        },
+        {
+          "qg_id": "ab",
+          "kg_id": "4c31cfcb4fcca8119bacadf5ff9c7c3f",
+          "weight": 0.4999999999999998
+        },
+        {
+          "qg_id": "ab",
+          "kg_id": "f35fb52da54f92f60696a99e84bfa51a",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "ab",
+          "kg_id": "444737174a86b6215191c9ac6115486b",
+          "weight": 0.4999999999999998
+        },
+        {
+          "qg_id": "ab",
+          "kg_id": "9b613f3b2cf64f7a0b7ca99f716d67d6",
+          "weight": 0.9996952148735141
+        },
+        {
+          "qg_id": "ab",
+          "kg_id": "8efc24e375e9f21c0dcabd50d9df36e2",
+          "weight": 0.4999999999999998
+        },
+        {
+          "qg_id": "ab",
+          "kg_id": "43821d8754c5fd847b24ae5bff93cf0b",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "ab",
+          "kg_id": "ead0c39f0b111e2554d42e09c6639da7",
+          "weight": 0.6772190444071822
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "-5898394631341070232",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "-5656986478217796426",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "-7110906936486429361",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "3084290182600781392",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "-2297230824344335298",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "6812383251897921924",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "-1355512535334662944",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "6563824040180032251",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "-5246473483780280599",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "-1467859242207634949",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "s5",
+          "kg_id": "1d8103c5-ec7f-4113-b748-a831f50348ec",
+          "weight": 0.35494629941051015
+        },
+        {
+          "qg_id": "s25",
+          "kg_id": "a782b019-3deb-4df6-8e5f-a5e00606d2bf",
+          "weight": 0.008965406293893974
+        },
+        {
+          "qg_id": "s26",
+          "kg_id": "33f47eee-3df3-44e6-a794-6c0afb0c5e5b",
+          "weight": 0.021531300514223473
+        },
+        {
+          "qg_id": "s28",
+          "kg_id": "d5dbfcb3-012b-4a93-b08d-7977d3227c2b",
+          "weight": 0.0476342062535382
+        },
+        {
+          "qg_id": "s31",
+          "kg_id": "04c630e7-f050-436a-bd3b-cc9ab8d370a3",
+          "weight": 0.2946421395968455
+        },
+        {
+          "qg_id": "s36",
+          "kg_id": "ad82daf4-f7d4-4b7a-ab61-a6521ac60cac",
+          "weight": 0.07502710580926264
+        },
+        {
+          "qg_id": "s38",
+          "kg_id": "4c101a2b-dcd8-4ef5-833f-3bd6633e1ceb",
+          "weight": 0.25356645531326705
+        },
+        {
+          "qg_id": "s292",
+          "kg_id": "18c4cb08-d6db-4c18-b788-545a3b8ced36",
+          "weight": 0.0023964339823070446
+        },
+        {
+          "qg_id": "s293",
+          "kg_id": "48eab723-6fa1-4a75-8aa2-77baf3f03bed",
+          "weight": 0.0006717002916813986
+        },
+        {
+          "qg_id": "s294",
+          "kg_id": "cb718e50-ab7c-4853-b4a6-79050c88a457",
+          "weight": 0.011900825100940926
+        },
+        {
+          "qg_id": "s295",
+          "kg_id": "065e509d-c64b-4d56-93e2-c8bb303d19b2",
+          "weight": 0.006508540707087063
+        },
+        {
+          "qg_id": "s296",
+          "kg_id": "8f8613a5-93cb-44d2-a181-b09006a3d87f",
+          "weight": 0.020320168918329662
+        },
+        {
+          "qg_id": "s297",
+          "kg_id": "12a049b0-1c10-493c-9ef6-2143711313c1",
+          "weight": 0.0005805900406936626
+        },
+        {
+          "qg_id": "s298",
+          "kg_id": "e10558a3-363d-4af7-b179-e213d3f14b58",
+          "weight": 0.00747139282650533
+        }
+      ],
+      "score": 913.1693369252874
+    },
+    {
+      "node_bindings": [
+        {
+          "qg_id": "a",
+          "kg_id": [
+            "MONDO:0005090"
+          ]
+        },
+        {
+          "qg_id": "b",
+          "kg_id": [
+            "MESH:D011433",
+            "MESH:D000069470",
+            "MESH:D013881",
+            "MESH:D001712",
+            "MESH:D011398",
+            "MESH:D005473",
+            "CHEBI:3766",
+            "MESH:D008140",
+            "MESH:D014282",
+            "MESH:D011352",
+            "CHEBI:8871"
+          ],
+          "enriched_nodes": [
+            "MONDO:0045057"
+          ],
+          "p_value": 1.3816912125289792e-22,
+          "coalescence_method": "graph_enrichment"
+        },
+        {
+          "qg_id": "extra_qn_0",
+          "kg_id": [
+            "MONDO:0045057"
+          ]
+        }
+      ],
+      "edge_bindings": [
+        {
+          "qg_id": "ab",
+          "kg_id": "d14eb3961c1f7388e1d825087793b09c",
+          "weight": 0.9952594092303608
+        },
+        {
+          "qg_id": "ab",
+          "kg_id": "0f708fa3e227b1fc99acf54b86ab0067",
+          "weight": 0.4999999999999998
+        },
+        {
+          "qg_id": "ab",
+          "kg_id": "7e2638ffd0752352debdae9307986f8d",
+          "weight": 0.4999999999999998
+        },
+        {
+          "qg_id": "ab",
+          "kg_id": "5c92c1173e1b6b916355bc842d5c39e4",
+          "weight": 0.6772190444071822
+        },
+        {
+          "qg_id": "ab",
+          "kg_id": "d614c7ce9753c9c96776b0b8c0496b90",
+          "weight": 0.4999999999999998
+        },
+        {
+          "qg_id": "ab",
+          "kg_id": "f35fb52da54f92f60696a99e84bfa51a",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "ab",
+          "kg_id": "444737174a86b6215191c9ac6115486b",
+          "weight": 0.4999999999999998
+        },
+        {
+          "qg_id": "ab",
+          "kg_id": "4a11a33f29fdbe47355079b7f43d97d0",
+          "weight": 0.6772190444071822
+        },
+        {
+          "qg_id": "ab",
+          "kg_id": "f07c7b7ecfe8842148bd274046d16b91",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "ab",
+          "kg_id": "b59a6c9652482f7a0b9f83afc9ae4146",
+          "weight": 0.4999999999999998
+        },
+        {
+          "qg_id": "ab",
+          "kg_id": "ead0c39f0b111e2554d42e09c6639da7",
+          "weight": 0.6772190444071822
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "-656478724480611462",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "4969228005349217352",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "-3096155888980392011",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "3907543275431847385",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "8845557262566355390",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "-596070693411112498",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "2550684820612963545",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "-8328219144568932710",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "4829079192796076469",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "1238654946301400555",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "-444417650432890117",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "s2",
+          "kg_id": "ac91e8d3-25b2-4a33-a705-53bb9e992169",
+          "weight": 0.0
+        },
+        {
+          "qg_id": "s7",
+          "kg_id": "10cc973f-a2c3-425a-88fc-053d40f9d05c",
+          "weight": 0.08212742799994421
+        },
+        {
+          "qg_id": "s11",
+          "kg_id": "785dec49-b2e6-4aed-a3d4-3ccf5ef5ba9a",
+          "weight": 0.03427319653363736
+        },
+        {
+          "qg_id": "s12",
+          "kg_id": "0ed76ed3-1ae6-4f2b-90b6-5af65e71863e",
+          "weight": 0.004461175571339071
+        },
+        {
+          "qg_id": "s15",
+          "kg_id": "92bd59d3-ae8b-4d45-b4be-c9edc87fffb9",
+          "weight": 0.07110386057201845
+        },
+        {
+          "qg_id": "s25",
+          "kg_id": "a782b019-3deb-4df6-8e5f-a5e00606d2bf",
+          "weight": 0.008965406293893974
+        },
+        {
+          "qg_id": "s28",
+          "kg_id": "d5dbfcb3-012b-4a93-b08d-7977d3227c2b",
+          "weight": 0.0476342062535382
+        },
+        {
+          "qg_id": "s31",
+          "kg_id": "04c630e7-f050-436a-bd3b-cc9ab8d370a3",
+          "weight": 0.2946421395968455
+        },
+        {
+          "qg_id": "s36",
+          "kg_id": "ad82daf4-f7d4-4b7a-ab61-a6521ac60cac",
+          "weight": 0.07502710580926264
+        },
+        {
+          "qg_id": "s301",
+          "kg_id": "436a295e-fa35-45af-b2f3-eda197095746",
+          "weight": 0.0
+        },
+        {
+          "qg_id": "s302",
+          "kg_id": "794682a0-c642-4886-8e5b-3cac630a099a",
+          "weight": 0.005992722300112829
+        },
+        {
+          "qg_id": "s303",
+          "kg_id": "807eb09a-8ec6-4a63-bc52-1084f10a46f2",
+          "weight": 0.016499830561808926
+        },
+        {
+          "qg_id": "s304",
+          "kg_id": "db7345bd-6363-4caf-9a59-5435850372b0",
+          "weight": 0.00552223100011795
+        },
+        {
+          "qg_id": "s305",
+          "kg_id": "03cf8183-fe7a-428d-80db-61b72c6c8ba2",
+          "weight": 0.008032727808281681
+        },
+        {
+          "qg_id": "s306",
+          "kg_id": "8f6819a0-41ce-4f8c-b68d-e614b08f9aae",
+          "weight": 0.013185340465110551
+        },
+        {
+          "qg_id": "s308",
+          "kg_id": "97b0288b-1dc2-4b19-9489-dc26ad268754",
+          "weight": 0.0747345428939612
+        },
+        {
+          "qg_id": "s309",
+          "kg_id": "de80bacf-a3ab-4879-896c-aa457b083381",
+          "weight": 0.008988759171737248
+        }
+      ],
+      "score": 6161.777856681035
+    },
+    {
+      "node_bindings": [
+        {
+          "qg_id": "a",
+          "kg_id": [
+            "MONDO:0005090"
+          ]
+        },
+        {
+          "qg_id": "b",
+          "kg_id": [
+            "CHEBI:8707",
+            "CHEBI:7735",
+            "CHEBI:5613",
+            "CHEBI:31236",
+            "CHEBI:65173",
+            "CHEBI:10119",
+            "CHEBI:70735",
+            "CHEBI:31981",
+            "CHEBI:8871"
+          ],
+          "enriched_nodes": [
+            "MONDO:0019790"
+          ],
+          "p_value": 2.4300439067757084e-22,
+          "coalescence_method": "graph_enrichment"
+        },
+        {
+          "qg_id": "extra_qn_0",
+          "kg_id": [
+            "MONDO:0019790"
+          ]
+        }
+      ],
+      "edge_bindings": [
+        {
+          "qg_id": "ab",
+          "kg_id": "14403bd92938ce4daec86a4771bf62e5",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "ab",
+          "kg_id": "5f9d7ec7475fcd03c7d0349c3d43ffd7",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "ab",
+          "kg_id": "1f6d1af9c9790d9e764acbcefa529560",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "ab",
+          "kg_id": "b10e8f04da87590a3f4594b55cb5f622",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "ab",
+          "kg_id": "25ca4674bccf3d3623ec99ddd401fef8",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "ab",
+          "kg_id": "f35fb52da54f92f60696a99e84bfa51a",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "ab",
+          "kg_id": "45bb9997c8ac47225836c8e74cf91b5a",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "ab",
+          "kg_id": "498c4c27bfd963f51fa822ad7f5a43cc",
+          "weight": 0.4999999999999998
+        },
+        {
+          "qg_id": "ab",
+          "kg_id": "43821d8754c5fd847b24ae5bff93cf0b",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "4512202911914841252",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "-1567770065749621750",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "1790838186176958393",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "-2405426274601481230",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "890830977484141548",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "-5525280665136049290",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "536362018006234249",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "1969712760274854286",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "749738027475068939",
+          "weight": 0.2679491924311228
+        }
+      ],
+      "score": 109.10848778735631
+    },
+    {
+      "node_bindings": [
+        {
+          "qg_id": "a",
+          "kg_id": [
+            "MONDO:0005090"
+          ]
+        },
+        {
+          "qg_id": "b",
+          "kg_id": [
+            "CHEBI:10119",
+            "CHEBI:8707",
+            "CHEBI:7735",
+            "CHEBI:3766",
+            "CHEBI:5613",
+            "CHEBI:31236",
+            "CHEBI:65173",
+            "CHEBI:8871"
+          ],
+          "enriched_nodes": [
+            "MONDO:0024290"
+          ],
+          "p_value": 2.9306352314601984e-22,
+          "coalescence_method": "graph_enrichment"
+        },
+        {
+          "qg_id": "extra_qn_0",
+          "kg_id": [
+            "MONDO:0024290"
+          ]
+        }
+      ],
+      "edge_bindings": [
+        {
+          "qg_id": "ab",
+          "kg_id": "14403bd92938ce4daec86a4771bf62e5",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "ab",
+          "kg_id": "5f9d7ec7475fcd03c7d0349c3d43ffd7",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "ab",
+          "kg_id": "1f6d1af9c9790d9e764acbcefa529560",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "ab",
+          "kg_id": "45bb9997c8ac47225836c8e74cf91b5a",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "ab",
+          "kg_id": "f07c7b7ecfe8842148bd274046d16b91",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "ab",
+          "kg_id": "b10e8f04da87590a3f4594b55cb5f622",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "ab",
+          "kg_id": "43821d8754c5fd847b24ae5bff93cf0b",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "ab",
+          "kg_id": "f35fb52da54f92f60696a99e84bfa51a",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "8542822586804373161",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "-147945709847765882",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "7656975687969885487",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "-2021766335042953923",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "-6326421212446071515",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "4670643061456322902",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "-8068557856541243433",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "-4707088294444374753",
+          "weight": 0.2679491924311228
+        }
+      ],
+      "score": 109.10848778735631
+    },
+    {
+      "node_bindings": [
+        {
+          "qg_id": "a",
+          "kg_id": [
+            "MONDO:0005090"
+          ]
+        },
+        {
+          "qg_id": "b",
+          "kg_id": [
+            "CHEBI:8707",
+            "CHEBI:7735",
+            "CHEBI:5613",
+            "CHEBI:31236",
+            "CHEBI:65173",
+            "CHEBI:10119",
+            "CHEBI:3766",
+            "CHEBI:70735",
+            "CHEBI:31981",
+            "CHEBI:8871"
+          ],
+          "enriched_nodes": [
+            "MONDO:0004901"
+          ],
+          "p_value": 3.009344234824553e-22,
+          "coalescence_method": "graph_enrichment"
+        },
+        {
+          "qg_id": "extra_qn_0",
+          "kg_id": [
+            "MONDO:0004901"
+          ]
+        }
+      ],
+      "edge_bindings": [
+        {
+          "qg_id": "ab",
+          "kg_id": "14403bd92938ce4daec86a4771bf62e5",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "ab",
+          "kg_id": "5f9d7ec7475fcd03c7d0349c3d43ffd7",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "ab",
+          "kg_id": "1f6d1af9c9790d9e764acbcefa529560",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "ab",
+          "kg_id": "b10e8f04da87590a3f4594b55cb5f622",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "ab",
+          "kg_id": "25ca4674bccf3d3623ec99ddd401fef8",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "ab",
+          "kg_id": "f35fb52da54f92f60696a99e84bfa51a",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "ab",
+          "kg_id": "f07c7b7ecfe8842148bd274046d16b91",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "ab",
+          "kg_id": "45bb9997c8ac47225836c8e74cf91b5a",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "ab",
+          "kg_id": "498c4c27bfd963f51fa822ad7f5a43cc",
+          "weight": 0.4999999999999998
+        },
+        {
+          "qg_id": "ab",
+          "kg_id": "43821d8754c5fd847b24ae5bff93cf0b",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "-2415909900249058287",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "-4612060353549820728",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "-991557068985754144",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "-130708114319489101",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "-8785374085166812445",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "7590189071645844058",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "-1117355485937735094",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "290163633554340036",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "715147255528557996",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "3780122642844902162",
+          "weight": 0.2679491924311228
+        }
+      ],
+      "score": 109.10848778735631
+    },
+    {
+      "node_bindings": [
+        {
+          "qg_id": "a",
+          "kg_id": [
+            "MONDO:0005090"
+          ]
+        },
+        {
+          "qg_id": "b",
+          "kg_id": [
+            "CHEBI:7735",
+            "MESH:D000069470",
+            "CHEBI:5613",
+            "MESH:D013469",
+            "MESH:D005473",
+            "MESH:D013881",
+            "MESH:C007761",
+            "MESH:D000077582",
+            "CHEBI:8871"
+          ],
+          "enriched_nodes": [
+            "MONDO:0006966"
+          ],
+          "p_value": 1.0301425505192476e-21,
+          "coalescence_method": "graph_enrichment"
+        },
+        {
+          "qg_id": "extra_qn_0",
+          "kg_id": [
+            "MONDO:0006966"
+          ]
+        }
+      ],
+      "edge_bindings": [
+        {
+          "qg_id": "ab",
+          "kg_id": "d14eb3961c1f7388e1d825087793b09c",
+          "weight": 0.9952594092303608
+        },
+        {
+          "qg_id": "ab",
+          "kg_id": "5f9d7ec7475fcd03c7d0349c3d43ffd7",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "ab",
+          "kg_id": "faf12afc64a27e030125dd3011fcff06",
+          "weight": 0.6772190444071822
+        },
+        {
+          "qg_id": "ab",
+          "kg_id": "0f708fa3e227b1fc99acf54b86ab0067",
+          "weight": 0.4999999999999998
+        },
+        {
+          "qg_id": "ab",
+          "kg_id": "b10e8f04da87590a3f4594b55cb5f622",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "ab",
+          "kg_id": "d614c7ce9753c9c96776b0b8c0496b90",
+          "weight": 0.4999999999999998
+        },
+        {
+          "qg_id": "ab",
+          "kg_id": "4c31cfcb4fcca8119bacadf5ff9c7c3f",
+          "weight": 0.4999999999999998
+        },
+        {
+          "qg_id": "ab",
+          "kg_id": "f35fb52da54f92f60696a99e84bfa51a",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "ab",
+          "kg_id": "9b613f3b2cf64f7a0b7ca99f716d67d6",
+          "weight": 0.9996952148735141
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "4472155025705701703",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "-7695570740792934769",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "-6434418878331110940",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "-8375415938181510877",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "-7776050621177909269",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "8090437576813410617",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "5898689963278938072",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "-343993704634168217",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "8005959358780681990",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "s5",
+          "kg_id": "1d8103c5-ec7f-4113-b748-a831f50348ec",
+          "weight": 0.35494629941051015
+        },
+        {
+          "qg_id": "s12",
+          "kg_id": "0ed76ed3-1ae6-4f2b-90b6-5af65e71863e",
+          "weight": 0.004461175571339071
+        },
+        {
+          "qg_id": "s28",
+          "kg_id": "d5dbfcb3-012b-4a93-b08d-7977d3227c2b",
+          "weight": 0.0476342062535382
+        },
+        {
+          "qg_id": "s31",
+          "kg_id": "04c630e7-f050-436a-bd3b-cc9ab8d370a3",
+          "weight": 0.2946421395968455
+        },
+        {
+          "qg_id": "s37",
+          "kg_id": "a1d12a86-1869-40c0-b989-7dddb20fd3e3",
+          "weight": 0.043592053932963504
+        },
+        {
+          "qg_id": "s38",
+          "kg_id": "4c101a2b-dcd8-4ef5-833f-3bd6633e1ceb",
+          "weight": 0.25356645531326705
+        },
+        {
+          "qg_id": "s335",
+          "kg_id": "dd2170b3-8ffc-463a-a5a4-55be6a0950e0",
+          "weight": 0.0017740886563519798
+        },
+        {
+          "qg_id": "s337",
+          "kg_id": "c94ca951-813a-443f-bfb7-39d6a3cf11b5",
+          "weight": 0.020149386954118498
+        },
+        {
+          "qg_id": "s338",
+          "kg_id": "b665b3fc-0558-44ee-92ba-2b318731875c",
+          "weight": 0.00790712378678915
+        },
+        {
+          "qg_id": "s339",
+          "kg_id": "ca5e74d3-3261-4261-b0a8-7016ad250f61",
+          "weight": 0.014835527121711545
+        },
+        {
+          "qg_id": "s340",
+          "kg_id": "acdb2db7-846e-4382-a828-14f052c9c933",
+          "weight": 0.0013624514095842422
+        },
+        {
+          "qg_id": "s341",
+          "kg_id": "4f30bd51-ec21-4376-91d8-5475995b6eb0",
+          "weight": 0.0006071847159130339
+        }
+      ],
+      "score": 3990.097790229886
+    },
+    {
+      "node_bindings": [
+        {
+          "qg_id": "a",
+          "kg_id": [
+            "MONDO:0005090"
+          ]
+        },
+        {
+          "qg_id": "b",
+          "kg_id": [
+            "CHEBI:8707",
+            "CHEBI:7735",
+            "CHEBI:5613",
+            "CHEBI:31236",
+            "CHEBI:65173",
+            "CHEBI:10119",
+            "CHEBI:3766",
+            "CHEBI:70735",
+            "CHEBI:8871"
+          ],
+          "enriched_nodes": [
+            "MONDO:0003785"
+          ],
+          "p_value": 1.4601893153242382e-21,
+          "coalescence_method": "graph_enrichment"
+        },
+        {
+          "qg_id": "extra_qn_0",
+          "kg_id": [
+            "MONDO:0003785"
+          ]
+        }
+      ],
+      "edge_bindings": [
+        {
+          "qg_id": "ab",
+          "kg_id": "14403bd92938ce4daec86a4771bf62e5",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "ab",
+          "kg_id": "5f9d7ec7475fcd03c7d0349c3d43ffd7",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "ab",
+          "kg_id": "1f6d1af9c9790d9e764acbcefa529560",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "ab",
+          "kg_id": "b10e8f04da87590a3f4594b55cb5f622",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "ab",
+          "kg_id": "25ca4674bccf3d3623ec99ddd401fef8",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "ab",
+          "kg_id": "f35fb52da54f92f60696a99e84bfa51a",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "ab",
+          "kg_id": "f07c7b7ecfe8842148bd274046d16b91",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "ab",
+          "kg_id": "45bb9997c8ac47225836c8e74cf91b5a",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "ab",
+          "kg_id": "43821d8754c5fd847b24ae5bff93cf0b",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "1151082609200863275",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "-5543314019251124207",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "3037040147538452399",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "7172847571873268777",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "-3478436096299504185",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "-1493886004187156196",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "-7973343595510248423",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "-8390038245075116980",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "5864746648622600259",
+          "weight": 0.2679491924311228
+        }
+      ],
+      "score": 109.10848778735631
+    },
+    {
+      "node_bindings": [
+        {
+          "qg_id": "a",
+          "kg_id": [
+            "MONDO:0005090"
+          ]
+        },
+        {
+          "qg_id": "b",
+          "kg_id": [
+            "CHEBI:10119",
+            "CHEBI:8707",
+            "CHEBI:7735",
+            "CHEBI:5613",
+            "CHEBI:70735",
+            "CHEBI:31236",
+            "CHEBI:65173",
+            "CHEBI:8871"
+          ],
+          "enriched_nodes": [
+            "MONDO:0010096"
+          ],
+          "p_value": 3.225496433896004e-21,
+          "coalescence_method": "graph_enrichment"
+        },
+        {
+          "qg_id": "extra_qn_0",
+          "kg_id": [
+            "MONDO:0010096"
+          ]
+        }
+      ],
+      "edge_bindings": [
+        {
+          "qg_id": "ab",
+          "kg_id": "14403bd92938ce4daec86a4771bf62e5",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "ab",
+          "kg_id": "5f9d7ec7475fcd03c7d0349c3d43ffd7",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "ab",
+          "kg_id": "1f6d1af9c9790d9e764acbcefa529560",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "ab",
+          "kg_id": "45bb9997c8ac47225836c8e74cf91b5a",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "ab",
+          "kg_id": "b10e8f04da87590a3f4594b55cb5f622",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "ab",
+          "kg_id": "43821d8754c5fd847b24ae5bff93cf0b",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "ab",
+          "kg_id": "25ca4674bccf3d3623ec99ddd401fef8",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "ab",
+          "kg_id": "f35fb52da54f92f60696a99e84bfa51a",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "-2659774116088053971",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "477007404452135758",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "-4636235250064105858",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "-1699485868356524057",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "-6475079625806153041",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "7571025181304214549",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "-5291820913262841071",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "3316143687829002233",
+          "weight": 0.2679491924311228
+        }
+      ],
+      "score": 109.10848778735631
+    },
+    {
+      "node_bindings": [
+        {
+          "qg_id": "a",
+          "kg_id": [
+            "MONDO:0005090"
+          ]
+        },
+        {
+          "qg_id": "b",
+          "kg_id": [
+            "MESH:D013469",
+            "MESH:D005473",
+            "CHEBI:7735",
+            "MESH:D008140",
+            "MESH:D000069470",
+            "MESH:D013881",
+            "CHEBI:8871"
+          ],
+          "enriched_nodes": [
+            "MONDO:0005146"
+          ],
+          "p_value": 4.672153956881842e-21,
+          "coalescence_method": "graph_enrichment"
+        },
+        {
+          "qg_id": "extra_qn_0",
+          "kg_id": [
+            "MONDO:0005146"
+          ]
+        }
+      ],
+      "edge_bindings": [
+        {
+          "qg_id": "ab",
+          "kg_id": "d14eb3961c1f7388e1d825087793b09c",
+          "weight": 0.9952594092303608
+        },
+        {
+          "qg_id": "ab",
+          "kg_id": "4a11a33f29fdbe47355079b7f43d97d0",
+          "weight": 0.6772190444071822
+        },
+        {
+          "qg_id": "ab",
+          "kg_id": "0f708fa3e227b1fc99acf54b86ab0067",
+          "weight": 0.4999999999999998
+        },
+        {
+          "qg_id": "ab",
+          "kg_id": "b10e8f04da87590a3f4594b55cb5f622",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "ab",
+          "kg_id": "d614c7ce9753c9c96776b0b8c0496b90",
+          "weight": 0.4999999999999998
+        },
+        {
+          "qg_id": "ab",
+          "kg_id": "4c31cfcb4fcca8119bacadf5ff9c7c3f",
+          "weight": 0.4999999999999998
+        },
+        {
+          "qg_id": "ab",
+          "kg_id": "f35fb52da54f92f60696a99e84bfa51a",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "1691533969603075578",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "8892907267196242590",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "6242426350546455277",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "6680602685400644629",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "-1321249648166313799",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "8151367887479310133",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "4614858993641184753",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "s5",
+          "kg_id": "1d8103c5-ec7f-4113-b748-a831f50348ec",
+          "weight": 0.35494629941051015
+        },
+        {
+          "qg_id": "s7",
+          "kg_id": "10cc973f-a2c3-425a-88fc-053d40f9d05c",
+          "weight": 0.08212742799994421
+        },
+        {
+          "qg_id": "s12",
+          "kg_id": "0ed76ed3-1ae6-4f2b-90b6-5af65e71863e",
+          "weight": 0.004461175571339071
+        },
+        {
+          "qg_id": "s28",
+          "kg_id": "d5dbfcb3-012b-4a93-b08d-7977d3227c2b",
+          "weight": 0.0476342062535382
+        },
+        {
+          "qg_id": "s31",
+          "kg_id": "04c630e7-f050-436a-bd3b-cc9ab8d370a3",
+          "weight": 0.2946421395968455
+        },
+        {
+          "qg_id": "s354",
+          "kg_id": "12806415-9f97-4d34-9857-72fb6885dce8",
+          "weight": 0.00020199712113000423
+        },
+        {
+          "qg_id": "s355",
+          "kg_id": "b220423f-1e58-4d5a-9250-9cd99b300ce4",
+          "weight": 0.04322383501240301
+        },
+        {
+          "qg_id": "s357",
+          "kg_id": "d02bfccf-a7a6-4749-bf23-843d4b36ecbd",
+          "weight": 0.000603087463797447
+        },
+        {
+          "qg_id": "s358",
+          "kg_id": "da330570-1c52-4a70-87cd-a53e55575437",
+          "weight": 0.02083674002843594
+        },
+        {
+          "qg_id": "s359",
+          "kg_id": "4d2d0f2c-559f-43a5-8b29-f0f62a9287f2",
+          "weight": 0.0
+        }
+      ],
+      "score": 3990.097790229886
+    },
+    {
+      "node_bindings": [
+        {
+          "qg_id": "a",
+          "kg_id": [
+            "MONDO:0005090"
+          ]
+        },
+        {
+          "qg_id": "b",
+          "kg_id": [
+            "CHEBI:7735",
+            "CHEBI:31236",
+            "MESH:D001712",
+            "CHEBI:10119",
+            "MESH:D011398",
+            "MESH:D012906",
+            "CHEBI:3766",
+            "MESH:D008140",
+            "MESH:D014282",
+            "MESH:D000077582",
+            "CHEBI:8871"
+          ],
+          "enriched_nodes": [
+            "HP:0001662"
+          ],
+          "p_value": 4.878163616442148e-21,
+          "coalescence_method": "graph_enrichment"
+        },
+        {
+          "qg_id": "extra_qn_0",
+          "kg_id": [
+            "HP:0001662"
+          ]
+        }
+      ],
+      "edge_bindings": [
+        {
+          "qg_id": "ab",
+          "kg_id": "7e2638ffd0752352debdae9307986f8d",
+          "weight": 0.4999999999999998
+        },
+        {
+          "qg_id": "ab",
+          "kg_id": "b10e8f04da87590a3f4594b55cb5f622",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "ab",
+          "kg_id": "f35fb52da54f92f60696a99e84bfa51a",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "ab",
+          "kg_id": "ecd1e07e353f9416c93c3e9b5e098d77",
+          "weight": 0.4999999999999998
+        },
+        {
+          "qg_id": "ab",
+          "kg_id": "444737174a86b6215191c9ac6115486b",
+          "weight": 0.4999999999999998
+        },
+        {
+          "qg_id": "ab",
+          "kg_id": "9b613f3b2cf64f7a0b7ca99f716d67d6",
+          "weight": 0.9996952148735141
+        },
+        {
+          "qg_id": "ab",
+          "kg_id": "4a11a33f29fdbe47355079b7f43d97d0",
+          "weight": 0.6772190444071822
+        },
+        {
+          "qg_id": "ab",
+          "kg_id": "f07c7b7ecfe8842148bd274046d16b91",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "ab",
+          "kg_id": "45bb9997c8ac47225836c8e74cf91b5a",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "ab",
+          "kg_id": "43821d8754c5fd847b24ae5bff93cf0b",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "ab",
+          "kg_id": "ead0c39f0b111e2554d42e09c6639da7",
+          "weight": 0.6772190444071822
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "4633906128651013773",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "-7342722676319400886",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "2485370548408504772",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "-6448075984934064950",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "3382542443408984595",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "8529029421556101359",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "533851379061900976",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "8969528000965101023",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "502915809376163867",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "3914709103277830391",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "-3699738814561811808",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "s7",
+          "kg_id": "10cc973f-a2c3-425a-88fc-053d40f9d05c",
+          "weight": 0.08212742799994421
+        },
+        {
+          "qg_id": "s15",
+          "kg_id": "92bd59d3-ae8b-4d45-b4be-c9edc87fffb9",
+          "weight": 0.07110386057201845
+        },
+        {
+          "qg_id": "s25",
+          "kg_id": "a782b019-3deb-4df6-8e5f-a5e00606d2bf",
+          "weight": 0.008965406293893974
+        },
+        {
+          "qg_id": "s27",
+          "kg_id": "9392cd8f-8cf6-465a-bb1f-5af5a9db2690",
+          "weight": 0.0
+        },
+        {
+          "qg_id": "s36",
+          "kg_id": "ad82daf4-f7d4-4b7a-ab61-a6521ac60cac",
+          "weight": 0.07502710580926264
+        },
+        {
+          "qg_id": "s38",
+          "kg_id": "4c101a2b-dcd8-4ef5-833f-3bd6633e1ceb",
+          "weight": 0.25356645531326705
+        },
+        {
+          "qg_id": "s361",
+          "kg_id": "14b1fb28-7666-482d-919f-7c864cb38663",
+          "weight": 0.0
+        },
+        {
+          "qg_id": "s364",
+          "kg_id": "47a22d2a-f765-4fdf-bf31-dd3ce6df5f8a",
+          "weight": 0.00040110474570154153
+        },
+        {
+          "qg_id": "s366",
+          "kg_id": "c9ea8250-99c6-4b4e-8483-3ef348f68377",
+          "weight": 0.004987186185518633
+        },
+        {
+          "qg_id": "s367",
+          "kg_id": "8abb4c26-cb25-4a1a-9951-0d10ef0ad43a",
+          "weight": 0.008608592449006691
+        },
+        {
+          "qg_id": "s369",
+          "kg_id": "2e24012f-5e90-46df-855f-cc81fd6f3e0e",
+          "weight": 0.00509049958346508
+        },
+        {
+          "qg_id": "s370",
+          "kg_id": "0e24deb4-29dd-40d7-a3ea-70a8af00e515",
+          "weight": 0.001490719583705502
+        },
+        {
+          "qg_id": "s371",
+          "kg_id": "976a5e21-8c64-4467-bf4e-9aef2544eca9",
+          "weight": 0.0029960963594566348
+        }
+      ],
+      "score": 6161.777856681035
+    },
+    {
+      "node_bindings": [
+        {
+          "qg_id": "a",
+          "kg_id": [
+            "MONDO:0005090"
+          ]
+        },
+        {
+          "qg_id": "b",
+          "kg_id": [
+            "MESH:D011433",
+            "CHEBI:7735",
+            "CHEBI:5613",
+            "MESH:D013881",
+            "MESH:D011398",
+            "MESH:D008653",
+            "CHEBI:3766",
+            "MESH:D008140",
+            "MESH:D000077582",
+            "CHEBI:8871"
+          ],
+          "enriched_nodes": [
+            "MONDO:0005640"
+          ],
+          "p_value": 5.136624059162829e-21,
+          "coalescence_method": "graph_enrichment"
+        },
+        {
+          "qg_id": "extra_qn_0",
+          "kg_id": [
+            "MONDO:0005640"
+          ]
+        }
+      ],
+      "edge_bindings": [
+        {
+          "qg_id": "ab",
+          "kg_id": "d14eb3961c1f7388e1d825087793b09c",
+          "weight": 0.9952594092303608
+        },
+        {
+          "qg_id": "ab",
+          "kg_id": "5f9d7ec7475fcd03c7d0349c3d43ffd7",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "ab",
+          "kg_id": "b10e8f04da87590a3f4594b55cb5f622",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "ab",
+          "kg_id": "f35fb52da54f92f60696a99e84bfa51a",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "ab",
+          "kg_id": "444737174a86b6215191c9ac6115486b",
+          "weight": 0.4999999999999998
+        },
+        {
+          "qg_id": "ab",
+          "kg_id": "9b613f3b2cf64f7a0b7ca99f716d67d6",
+          "weight": 0.9996952148735141
+        },
+        {
+          "qg_id": "ab",
+          "kg_id": "4a11a33f29fdbe47355079b7f43d97d0",
+          "weight": 0.6772190444071822
+        },
+        {
+          "qg_id": "ab",
+          "kg_id": "8efc24e375e9f21c0dcabd50d9df36e2",
+          "weight": 0.4999999999999998
+        },
+        {
+          "qg_id": "ab",
+          "kg_id": "f07c7b7ecfe8842148bd274046d16b91",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "ab",
+          "kg_id": "b59a6c9652482f7a0b9f83afc9ae4146",
+          "weight": 0.4999999999999998
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "-1263327851930119739",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "-7909593984536737112",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "-4075516581501838766",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "-1929211694600666960",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "8459921619798609578",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "-1886762736391704635",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "6000514696491204873",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "-369958072781298469",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "45547578499009774",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "-8433299558252010856",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "s2",
+          "kg_id": "ac91e8d3-25b2-4a33-a705-53bb9e992169",
+          "weight": 0.0
+        },
+        {
+          "qg_id": "s7",
+          "kg_id": "10cc973f-a2c3-425a-88fc-053d40f9d05c",
+          "weight": 0.08212742799994421
+        },
+        {
+          "qg_id": "s25",
+          "kg_id": "a782b019-3deb-4df6-8e5f-a5e00606d2bf",
+          "weight": 0.008965406293893974
+        },
+        {
+          "qg_id": "s26",
+          "kg_id": "33f47eee-3df3-44e6-a794-6c0afb0c5e5b",
+          "weight": 0.021531300514223473
+        },
+        {
+          "qg_id": "s31",
+          "kg_id": "04c630e7-f050-436a-bd3b-cc9ab8d370a3",
+          "weight": 0.2946421395968455
+        },
+        {
+          "qg_id": "s38",
+          "kg_id": "4c101a2b-dcd8-4ef5-833f-3bd6633e1ceb",
+          "weight": 0.25356645531326705
+        },
+        {
+          "qg_id": "s381",
+          "kg_id": "e7bda5c2-0470-4b09-a37d-780401390225",
+          "weight": 0.0013228336878985392
+        }
+      ],
+      "score": 6161.777856681035
+    },
+    {
+      "node_bindings": [
+        {
+          "qg_id": "a",
+          "kg_id": [
+            "MONDO:0005090"
+          ]
+        },
+        {
+          "qg_id": "b",
+          "kg_id": [
+            "MESH:C030265",
+            "MESH:D013469",
+            "CHEBI:7735",
+            "CHEBI:3766",
+            "MESH:D000069470",
+            "CHEBI:31236",
+            "CHEBI:8871"
+          ],
+          "enriched_nodes": [
+            "MONDO:0002265"
+          ],
+          "p_value": 8.58798881110012e-21,
+          "coalescence_method": "graph_enrichment"
+        },
+        {
+          "qg_id": "extra_qn_0",
+          "kg_id": [
+            "MONDO:0002265"
+          ]
+        }
+      ],
+      "edge_bindings": [
+        {
+          "qg_id": "ab",
+          "kg_id": "0f708fa3e227b1fc99acf54b86ab0067",
+          "weight": 0.4999999999999998
+        },
+        {
+          "qg_id": "ab",
+          "kg_id": "f07c7b7ecfe8842148bd274046d16b91",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "ab",
+          "kg_id": "45bb9997c8ac47225836c8e74cf91b5a",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "ab",
+          "kg_id": "926bbe3b8fa81d53f421602d766bccde",
+          "weight": 0.4999999999999998
+        },
+        {
+          "qg_id": "ab",
+          "kg_id": "b10e8f04da87590a3f4594b55cb5f622",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "ab",
+          "kg_id": "4c31cfcb4fcca8119bacadf5ff9c7c3f",
+          "weight": 0.4999999999999998
+        },
+        {
+          "qg_id": "ab",
+          "kg_id": "f35fb52da54f92f60696a99e84bfa51a",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "2219163019593104585",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "-632655828542236565",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "2076692700165479703",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "-1621385507383895139",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "5256552198841176169",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "5473425858982591361",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "1807084107643763941",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "s5",
+          "kg_id": "1d8103c5-ec7f-4113-b748-a831f50348ec",
+          "weight": 0.35494629941051015
+        },
+        {
+          "qg_id": "s12",
+          "kg_id": "0ed76ed3-1ae6-4f2b-90b6-5af65e71863e",
+          "weight": 0.004461175571339071
+        },
+        {
+          "qg_id": "s19",
+          "kg_id": "b700e850-b64b-4b7c-b2ae-0bad66f71a3e",
+          "weight": 0.019762199631277122
+        },
+        {
+          "qg_id": "s384",
+          "kg_id": "c0de62aa-d8fa-4443-972b-fca3b3a6d4b4",
+          "weight": 0.13610330665387682
+        },
+        {
+          "qg_id": "s385",
+          "kg_id": "1c97380a-bec6-47a3-97b8-358b51e5a3df",
+          "weight": 0.008163819931399363
+        },
+        {
+          "qg_id": "s386",
+          "kg_id": "cb85b966-ded4-43fb-9649-c70f4ae409ad",
+          "weight": 0.07895507178976868
+        },
+        {
+          "qg_id": "s389",
+          "kg_id": "774a1f68-1434-466f-915d-23b9b0cf85c6",
+          "weight": 0.0019686238872038686
+        }
+      ],
+      "score": 6161.777856681035
+    },
+    {
+      "node_bindings": [
+        {
+          "qg_id": "a",
+          "kg_id": [
+            "MONDO:0005090"
+          ]
+        },
+        {
+          "qg_id": "b",
+          "kg_id": [
+            "MESH:D011433",
+            "MESH:D000069470",
+            "CHEBI:5613",
+            "MESH:D013881",
+            "CHEBI:10119",
+            "MESH:D013469",
+            "MESH:D005473",
+            "CHEBI:3766",
+            "MESH:D008140",
+            "MESH:C007761",
+            "CHEBI:8871"
+          ],
+          "enriched_nodes": [
+            "MONDO:0005395"
+          ],
+          "p_value": 1.1203812972030409e-20,
+          "coalescence_method": "graph_enrichment"
+        },
+        {
+          "qg_id": "extra_qn_0",
+          "kg_id": [
+            "MONDO:0005395"
+          ]
+        }
+      ],
+      "edge_bindings": [
+        {
+          "qg_id": "ab",
+          "kg_id": "d14eb3961c1f7388e1d825087793b09c",
+          "weight": 0.9952594092303608
+        },
+        {
+          "qg_id": "ab",
+          "kg_id": "5f9d7ec7475fcd03c7d0349c3d43ffd7",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "ab",
+          "kg_id": "faf12afc64a27e030125dd3011fcff06",
+          "weight": 0.6772190444071822
+        },
+        {
+          "qg_id": "ab",
+          "kg_id": "0f708fa3e227b1fc99acf54b86ab0067",
+          "weight": 0.4999999999999998
+        },
+        {
+          "qg_id": "ab",
+          "kg_id": "d614c7ce9753c9c96776b0b8c0496b90",
+          "weight": 0.4999999999999998
+        },
+        {
+          "qg_id": "ab",
+          "kg_id": "4c31cfcb4fcca8119bacadf5ff9c7c3f",
+          "weight": 0.4999999999999998
+        },
+        {
+          "qg_id": "ab",
+          "kg_id": "f35fb52da54f92f60696a99e84bfa51a",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "ab",
+          "kg_id": "4a11a33f29fdbe47355079b7f43d97d0",
+          "weight": 0.6772190444071822
+        },
+        {
+          "qg_id": "ab",
+          "kg_id": "f07c7b7ecfe8842148bd274046d16b91",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "ab",
+          "kg_id": "b59a6c9652482f7a0b9f83afc9ae4146",
+          "weight": 0.4999999999999998
+        },
+        {
+          "qg_id": "ab",
+          "kg_id": "43821d8754c5fd847b24ae5bff93cf0b",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "-3954255148019272249",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "516356348138027267",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "351082519169215044",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "-2971200935219760456",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "-6425529449743513845",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "8190705034527981799",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "-2007823561432491652",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "-9200739895670295319",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "-5993017496814361767",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "3131905890862032764",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "-3864173807480859764",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "s2",
+          "kg_id": "ac91e8d3-25b2-4a33-a705-53bb9e992169",
+          "weight": 0.0
+        },
+        {
+          "qg_id": "s5",
+          "kg_id": "1d8103c5-ec7f-4113-b748-a831f50348ec",
+          "weight": 0.35494629941051015
+        },
+        {
+          "qg_id": "s7",
+          "kg_id": "10cc973f-a2c3-425a-88fc-053d40f9d05c",
+          "weight": 0.08212742799994421
+        },
+        {
+          "qg_id": "s12",
+          "kg_id": "0ed76ed3-1ae6-4f2b-90b6-5af65e71863e",
+          "weight": 0.004461175571339071
+        },
+        {
+          "qg_id": "s28",
+          "kg_id": "d5dbfcb3-012b-4a93-b08d-7977d3227c2b",
+          "weight": 0.0476342062535382
+        },
+        {
+          "qg_id": "s31",
+          "kg_id": "04c630e7-f050-436a-bd3b-cc9ab8d370a3",
+          "weight": 0.2946421395968455
+        },
+        {
+          "qg_id": "s37",
+          "kg_id": "a1d12a86-1869-40c0-b989-7dddb20fd3e3",
+          "weight": 0.043592053932963504
+        },
+        {
+          "qg_id": "s392",
+          "kg_id": "e22b1f7f-1794-41d6-9644-2a3c6cde6429",
+          "weight": 0.0
+        },
+        {
+          "qg_id": "s393",
+          "kg_id": "0728362b-109f-436d-9286-79f7a58524de",
+          "weight": 0.009507939822160472
+        },
+        {
+          "qg_id": "s394",
+          "kg_id": "4b643bee-b377-4416-9d52-8eccd5d7ff85",
+          "weight": 0.0017637731424662295
+        },
+        {
+          "qg_id": "s396",
+          "kg_id": "1320bd09-009d-4746-8b0f-e8897a765175",
+          "weight": 0.023141656038651037
+        },
+        {
+          "qg_id": "s398",
+          "kg_id": "7ed06cf7-f058-4b43-91dd-7c951dfdd7ac",
+          "weight": 0.01730049831719116
+        },
+        {
+          "qg_id": "s399",
+          "kg_id": "7115a8d7-6d73-4b8f-9604-5a467ebf0185",
+          "weight": 0.005721133913842991
+        },
+        {
+          "qg_id": "s401",
+          "kg_id": "37e2b4de-103f-4f4b-9b33-2ced9152c7db",
+          "weight": 0.004980827394815757
+        },
+        {
+          "qg_id": "s402",
+          "kg_id": "7c18b605-551f-4671-b5d2-fa84bce2c393",
+          "weight": 0.0019967365262378856
+        }
+      ],
+      "score": 6161.777856681035
+    },
+    {
+      "node_bindings": [
+        {
+          "qg_id": "a",
+          "kg_id": [
+            "MONDO:0005090"
+          ]
+        },
+        {
+          "qg_id": "b",
+          "kg_id": [
+            "MESH:D011433",
+            "CHEBI:7735",
+            "MESH:D000069470",
+            "CHEBI:5613",
+            "MESH:C515050",
+            "MESH:D013881",
+            "MESH:D011398",
+            "MESH:D013469",
+            "MESH:D012906",
+            "CHEBI:3766",
+            "MESH:D005473",
+            "MESH:D014282",
+            "CHEBI:8871"
+          ],
+          "enriched_nodes": [
+            "MONDO:0005359"
+          ],
+          "p_value": 1.8004349400757203e-20,
+          "coalescence_method": "graph_enrichment"
+        },
+        {
+          "qg_id": "extra_qn_0",
+          "kg_id": [
+            "MONDO:0005359"
+          ]
+        }
+      ],
+      "edge_bindings": [
+        {
+          "qg_id": "ab",
+          "kg_id": "d14eb3961c1f7388e1d825087793b09c",
+          "weight": 0.9952594092303608
+        },
+        {
+          "qg_id": "ab",
+          "kg_id": "5f9d7ec7475fcd03c7d0349c3d43ffd7",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "ab",
+          "kg_id": "0f708fa3e227b1fc99acf54b86ab0067",
+          "weight": 0.4999999999999998
+        },
+        {
+          "qg_id": "ab",
+          "kg_id": "b10e8f04da87590a3f4594b55cb5f622",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "ab",
+          "kg_id": "d614c7ce9753c9c96776b0b8c0496b90",
+          "weight": 0.4999999999999998
+        },
+        {
+          "qg_id": "ab",
+          "kg_id": "4c31cfcb4fcca8119bacadf5ff9c7c3f",
+          "weight": 0.4999999999999998
+        },
+        {
+          "qg_id": "ab",
+          "kg_id": "f35fb52da54f92f60696a99e84bfa51a",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "ab",
+          "kg_id": "ecd1e07e353f9416c93c3e9b5e098d77",
+          "weight": 0.4999999999999998
+        },
+        {
+          "qg_id": "ab",
+          "kg_id": "444737174a86b6215191c9ac6115486b",
+          "weight": 0.4999999999999998
+        },
+        {
+          "qg_id": "ab",
+          "kg_id": "f07c7b7ecfe8842148bd274046d16b91",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "ab",
+          "kg_id": "b59a6c9652482f7a0b9f83afc9ae4146",
+          "weight": 0.4999999999999998
+        },
+        {
+          "qg_id": "ab",
+          "kg_id": "477e260e9fd1ccd91159dbe57337c22e",
+          "weight": 0.4999999999999998
+        },
+        {
+          "qg_id": "ab",
+          "kg_id": "ead0c39f0b111e2554d42e09c6639da7",
+          "weight": 0.6772190444071822
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "2448480368402111366",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "4679019237365139198",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "-1324873587069704642",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "6622030668805218261",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "3458782188535442396",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "95600692469403897",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "-6575588889842842676",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "-6781348368462337094",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "-4207176033649706558",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "3505740920049695710",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "899962618160977621",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "7419949375625482410",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "-173816170914167545",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "s2",
+          "kg_id": "ac91e8d3-25b2-4a33-a705-53bb9e992169",
+          "weight": 0.0
+        },
+        {
+          "qg_id": "s5",
+          "kg_id": "1d8103c5-ec7f-4113-b748-a831f50348ec",
+          "weight": 0.35494629941051015
+        },
+        {
+          "qg_id": "s12",
+          "kg_id": "0ed76ed3-1ae6-4f2b-90b6-5af65e71863e",
+          "weight": 0.004461175571339071
+        },
+        {
+          "qg_id": "s25",
+          "kg_id": "a782b019-3deb-4df6-8e5f-a5e00606d2bf",
+          "weight": 0.008965406293893974
+        },
+        {
+          "qg_id": "s27",
+          "kg_id": "9392cd8f-8cf6-465a-bb1f-5af5a9db2690",
+          "weight": 0.0
+        },
+        {
+          "qg_id": "s28",
+          "kg_id": "d5dbfcb3-012b-4a93-b08d-7977d3227c2b",
+          "weight": 0.0476342062535382
+        },
+        {
+          "qg_id": "s31",
+          "kg_id": "04c630e7-f050-436a-bd3b-cc9ab8d370a3",
+          "weight": 0.2946421395968455
+        },
+        {
+          "qg_id": "s35",
+          "kg_id": "90b99036-281c-47a0-af2e-22722581baf5",
+          "weight": 0.002457651043953346
+        },
+        {
+          "qg_id": "s36",
+          "kg_id": "ad82daf4-f7d4-4b7a-ab61-a6521ac60cac",
+          "weight": 0.07502710580926264
+        },
+        {
+          "qg_id": "s405",
+          "kg_id": "a0fa83d4-f400-429c-ab03-7b052c16d799",
+          "weight": 0.0
+        },
+        {
+          "qg_id": "s407",
+          "kg_id": "7af1a78c-6e0a-4d3c-a47b-777f82f42aa3",
+          "weight": 0.006417024384407943
+        },
+        {
+          "qg_id": "s410",
+          "kg_id": "4d39039f-25f4-476b-bc8f-5ab729d793b8",
+          "weight": 0.0065222607424462176
+        },
+        {
+          "qg_id": "s411",
+          "kg_id": "a182fdde-070d-4568-b1b8-5b2545a08c80",
+          "weight": 0.017045942886295018
+        },
+        {
+          "qg_id": "s412",
+          "kg_id": "e842b819-fc45-498f-9033-f5d03959bc1f",
+          "weight": 0.0
+        },
+        {
+          "qg_id": "s413",
+          "kg_id": "ddad3e96-adee-4ee2-8512-bce07b43a764",
+          "weight": 0.0
+        },
+        {
+          "qg_id": "s415",
+          "kg_id": "1aa9e3dc-c871-495f-82b6-5029c4eb6d2a",
+          "weight": 0.008608359346595096
+        }
+      ],
+      "score": 6161.777856681035
+    },
+    {
+      "node_bindings": [
+        {
+          "qg_id": "a",
+          "kg_id": [
+            "MONDO:0005090"
+          ]
+        },
+        {
+          "qg_id": "b",
+          "kg_id": [
+            "CHEBI:8707",
+            "CHEBI:7735",
+            "CHEBI:5613",
+            "CHEBI:31236",
+            "CHEBI:65173",
+            "CHEBI:10119",
+            "CHEBI:70735",
+            "CHEBI:31981",
+            "CHEBI:8871"
+          ],
+          "enriched_nodes": [
+            "MONDO:0003233"
+          ],
+          "p_value": 3.381330832806143e-20,
+          "coalescence_method": "graph_enrichment"
+        },
+        {
+          "qg_id": "extra_qn_0",
+          "kg_id": [
+            "MONDO:0003233"
+          ]
+        }
+      ],
+      "edge_bindings": [
+        {
+          "qg_id": "ab",
+          "kg_id": "14403bd92938ce4daec86a4771bf62e5",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "ab",
+          "kg_id": "5f9d7ec7475fcd03c7d0349c3d43ffd7",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "ab",
+          "kg_id": "1f6d1af9c9790d9e764acbcefa529560",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "ab",
+          "kg_id": "b10e8f04da87590a3f4594b55cb5f622",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "ab",
+          "kg_id": "25ca4674bccf3d3623ec99ddd401fef8",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "ab",
+          "kg_id": "f35fb52da54f92f60696a99e84bfa51a",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "ab",
+          "kg_id": "45bb9997c8ac47225836c8e74cf91b5a",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "ab",
+          "kg_id": "498c4c27bfd963f51fa822ad7f5a43cc",
+          "weight": 0.4999999999999998
+        },
+        {
+          "qg_id": "ab",
+          "kg_id": "43821d8754c5fd847b24ae5bff93cf0b",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "3672488302189657159",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "3414135163758255509",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "-7622948537027898880",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "5059503884894913583",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "-1522931296995803856",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "1390338507571581389",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "-6093103728374067517",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "-2859151584559806805",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "-916651110502222290",
+          "weight": 0.2679491924311228
+        }
+      ],
+      "score": 109.10848778735631
+    },
+    {
+      "node_bindings": [
+        {
+          "qg_id": "a",
+          "kg_id": [
+            "MONDO:0005090"
+          ]
+        },
+        {
+          "qg_id": "b",
+          "kg_id": [
+            "CHEBI:8707",
+            "CHEBI:7735",
+            "CHEBI:31236",
+            "MESH:D001712",
+            "MESH:D012436",
+            "MESH:D013469",
+            "MESH:D013881",
+            "MESH:C007761",
+            "MESH:D000077582"
+          ],
+          "enriched_nodes": [
+            "MONDO:0002050"
+          ],
+          "p_value": 4.288788836820382e-20,
+          "coalescence_method": "graph_enrichment"
+        },
+        {
+          "qg_id": "extra_qn_0",
+          "kg_id": [
+            "MONDO:0002050"
+          ]
+        }
+      ],
+      "edge_bindings": [
+        {
+          "qg_id": "ab",
+          "kg_id": "d14eb3961c1f7388e1d825087793b09c",
+          "weight": 0.9952594092303608
+        },
+        {
+          "qg_id": "ab",
+          "kg_id": "14403bd92938ce4daec86a4771bf62e5",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "ab",
+          "kg_id": "faf12afc64a27e030125dd3011fcff06",
+          "weight": 0.6772190444071822
+        },
+        {
+          "qg_id": "ab",
+          "kg_id": "7e2638ffd0752352debdae9307986f8d",
+          "weight": 0.4999999999999998
+        },
+        {
+          "qg_id": "ab",
+          "kg_id": "b10e8f04da87590a3f4594b55cb5f622",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "ab",
+          "kg_id": "46d04f20397875b7376435c704c3bd02",
+          "weight": 0.4999999999999998
+        },
+        {
+          "qg_id": "ab",
+          "kg_id": "4c31cfcb4fcca8119bacadf5ff9c7c3f",
+          "weight": 0.4999999999999998
+        },
+        {
+          "qg_id": "ab",
+          "kg_id": "9b613f3b2cf64f7a0b7ca99f716d67d6",
+          "weight": 0.9996952148735141
+        },
+        {
+          "qg_id": "ab",
+          "kg_id": "45bb9997c8ac47225836c8e74cf91b5a",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "-4479439093956043075",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "-2273592518372039077",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "-3159421616328477133",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "-7405020777115070913",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "-252890658072196688",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "5918520347873757394",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "-8107549427554054062",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "-825645177523714017",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "2196118760754651698",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "s5",
+          "kg_id": "1d8103c5-ec7f-4113-b748-a831f50348ec",
+          "weight": 0.35494629941051015
+        },
+        {
+          "qg_id": "s15",
+          "kg_id": "92bd59d3-ae8b-4d45-b4be-c9edc87fffb9",
+          "weight": 0.07110386057201845
+        },
+        {
+          "qg_id": "s16",
+          "kg_id": "4d694c72-5629-4e7b-9210-3feb7d892a36",
+          "weight": 0.00968624868675172
+        },
+        {
+          "qg_id": "s31",
+          "kg_id": "04c630e7-f050-436a-bd3b-cc9ab8d370a3",
+          "weight": 0.2946421395968455
+        },
+        {
+          "qg_id": "s37",
+          "kg_id": "a1d12a86-1869-40c0-b989-7dddb20fd3e3",
+          "weight": 0.043592053932963504
+        },
+        {
+          "qg_id": "s38",
+          "kg_id": "4c101a2b-dcd8-4ef5-833f-3bd6633e1ceb",
+          "weight": 0.25356645531326705
+        },
+        {
+          "qg_id": "s428",
+          "kg_id": "4a4e7a67-6bc7-4049-9248-61114a1b0f73",
+          "weight": 0.09903082128908869
+        },
+        {
+          "qg_id": "s432",
+          "kg_id": "21adc088-adea-41e2-a459-451ba77164d6",
+          "weight": 0.01963801320519032
+        },
+        {
+          "qg_id": "s433",
+          "kg_id": "f06f2ec5-551e-4933-b268-dc4f87a5f354",
+          "weight": 0.09259798275770836
+        },
+        {
+          "qg_id": "s434",
+          "kg_id": "9f36e401-b0e9-43ce-8063-fd7fb87dc31f",
+          "weight": 0.140466022347145
+        },
+        {
+          "qg_id": "s435",
+          "kg_id": "b1e24050-81ed-4a69-aba3-9392ea6ee41c",
+          "weight": 0.09706785157066555
+        },
+        {
+          "qg_id": "s436",
+          "kg_id": "7a41702d-f102-41a5-b740-1189b61a4d24",
+          "weight": 0.008697720364828854
+        },
+        {
+          "qg_id": "s437",
+          "kg_id": "bdc477f0-0952-406f-b862-407b5010bc49",
+          "weight": 0.03651937268083061
+        }
+      ],
+      "score": 1437.196623922414
+    },
+    {
+      "node_bindings": [
+        {
+          "qg_id": "a",
+          "kg_id": [
+            "MONDO:0005090"
+          ]
+        },
+        {
+          "qg_id": "b",
+          "kg_id": [
+            "MESH:D013469",
+            "MESH:D008972",
+            "MESH:D008140",
+            "CHEBI:5613",
+            "MESH:C007761",
+            "MESH:D013881",
+            "MESH:D000077582",
+            "MESH:D001712"
+          ],
+          "enriched_nodes": [
+            "MONDO:0005485"
+          ],
+          "p_value": 4.450242022012566e-20,
+          "coalescence_method": "graph_enrichment"
+        },
+        {
+          "qg_id": "extra_qn_0",
+          "kg_id": [
+            "MONDO:0005485"
+          ]
+        }
+      ],
+      "edge_bindings": [
+        {
+          "qg_id": "ab",
+          "kg_id": "d14eb3961c1f7388e1d825087793b09c",
+          "weight": 0.9952594092303608
+        },
+        {
+          "qg_id": "ab",
+          "kg_id": "5f9d7ec7475fcd03c7d0349c3d43ffd7",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "ab",
+          "kg_id": "b81fdf71694595916d701accb5b538ac",
+          "weight": 0.7999999999999998
+        },
+        {
+          "qg_id": "ab",
+          "kg_id": "faf12afc64a27e030125dd3011fcff06",
+          "weight": 0.6772190444071822
+        },
+        {
+          "qg_id": "ab",
+          "kg_id": "9b613f3b2cf64f7a0b7ca99f716d67d6",
+          "weight": 0.9996952148735141
+        },
+        {
+          "qg_id": "ab",
+          "kg_id": "4a11a33f29fdbe47355079b7f43d97d0",
+          "weight": 0.6772190444071822
+        },
+        {
+          "qg_id": "ab",
+          "kg_id": "7e2638ffd0752352debdae9307986f8d",
+          "weight": 0.4999999999999998
+        },
+        {
+          "qg_id": "ab",
+          "kg_id": "4c31cfcb4fcca8119bacadf5ff9c7c3f",
+          "weight": 0.4999999999999998
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "2129885142373066310",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "7169429819460581860",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "4431982969745312871",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "6313309424769656585",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "-6410622664977230762",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "-2901908578201071617",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "1162435995179776008",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "4837347622653324937",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "s5",
+          "kg_id": "1d8103c5-ec7f-4113-b748-a831f50348ec",
+          "weight": 0.35494629941051015
+        },
+        {
+          "qg_id": "s7",
+          "kg_id": "10cc973f-a2c3-425a-88fc-053d40f9d05c",
+          "weight": 0.08212742799994421
+        },
+        {
+          "qg_id": "s15",
+          "kg_id": "92bd59d3-ae8b-4d45-b4be-c9edc87fffb9",
+          "weight": 0.07110386057201845
+        },
+        {
+          "qg_id": "s18",
+          "kg_id": "f235abe9-d66c-4777-aa7a-0b7c25a56a83",
+          "weight": 0.04000789911277636
+        },
+        {
+          "qg_id": "s31",
+          "kg_id": "04c630e7-f050-436a-bd3b-cc9ab8d370a3",
+          "weight": 0.2946421395968455
+        },
+        {
+          "qg_id": "s37",
+          "kg_id": "a1d12a86-1869-40c0-b989-7dddb20fd3e3",
+          "weight": 0.043592053932963504
+        },
+        {
+          "qg_id": "s38",
+          "kg_id": "4c101a2b-dcd8-4ef5-833f-3bd6633e1ceb",
+          "weight": 0.25356645531326705
+        },
+        {
+          "qg_id": "s438",
+          "kg_id": "2f09b56b-f7f5-40d5-877a-100ce84171ea",
+          "weight": 0.0
+        },
+        {
+          "qg_id": "s439",
+          "kg_id": "00228345-80b8-4a70-b44a-be520203b163",
+          "weight": 0.10481863656932311
+        },
+        {
+          "qg_id": "s440",
+          "kg_id": "c371b593-6348-4ea9-8b6a-aedc77900db8",
+          "weight": 0.016236553907440276
+        },
+        {
+          "qg_id": "s441",
+          "kg_id": "c74eee45-07ae-4c2c-88fc-f842e6920eed",
+          "weight": 0.07534154245929003
+        },
+        {
+          "qg_id": "s443",
+          "kg_id": "af45c835-6be1-4845-bda8-35dd6018cb79",
+          "weight": 0.007390312002226951
+        },
+        {
+          "qg_id": "s444",
+          "kg_id": "52efd8ba-5bd7-467f-92f9-7f879b4460c8",
+          "weight": 0.13586686328129627
+        },
+        {
+          "qg_id": "s445",
+          "kg_id": "81a5c970-b39b-418e-9457-73a6b8114c68",
+          "weight": 0.07146697429552207
+        },
+        {
+          "qg_id": "s446",
+          "kg_id": "a756a2b3-8bfc-4d24-82b0-36c506bb13ba",
+          "weight": 0.021189011733249385
+        }
+      ],
+      "score": 4556.930668103448
+    },
+    {
+      "node_bindings": [
+        {
+          "qg_id": "a",
+          "kg_id": [
+            "MONDO:0005090"
+          ]
+        },
+        {
+          "qg_id": "b",
+          "kg_id": [
+            "CHEBI:10119",
+            "CHEBI:8707",
+            "CHEBI:7735",
+            "CHEBI:3766",
+            "CHEBI:5613",
+            "CHEBI:31236",
+            "CHEBI:8871"
+          ],
+          "enriched_nodes": [
+            "MONDO:0005804"
+          ],
+          "p_value": 6.425104979046893e-20,
+          "coalescence_method": "graph_enrichment"
+        },
+        {
+          "qg_id": "extra_qn_0",
+          "kg_id": [
+            "MONDO:0005804"
+          ]
+        }
+      ],
+      "edge_bindings": [
+        {
+          "qg_id": "ab",
+          "kg_id": "14403bd92938ce4daec86a4771bf62e5",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "ab",
+          "kg_id": "5f9d7ec7475fcd03c7d0349c3d43ffd7",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "ab",
+          "kg_id": "45bb9997c8ac47225836c8e74cf91b5a",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "ab",
+          "kg_id": "f07c7b7ecfe8842148bd274046d16b91",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "ab",
+          "kg_id": "b10e8f04da87590a3f4594b55cb5f622",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "ab",
+          "kg_id": "43821d8754c5fd847b24ae5bff93cf0b",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "ab",
+          "kg_id": "f35fb52da54f92f60696a99e84bfa51a",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "961782262926722637",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "-4177584470336582610",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "5966198749260424432",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "7833007451189389640",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "3115079032542798102",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "8853877195794649514",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "-2300638039554984320",
+          "weight": 0.2679491924311228
+        }
+      ],
+      "score": 1437.196623922414
+    },
+    {
+      "node_bindings": [
+        {
+          "qg_id": "a",
+          "kg_id": [
+            "MONDO:0005090"
+          ]
+        },
+        {
+          "qg_id": "b",
+          "kg_id": [
+            "CHEBI:10119",
+            "CHEBI:8707",
+            "CHEBI:7735",
+            "CHEBI:3766",
+            "CHEBI:70735",
+            "CHEBI:31236",
+            "CHEBI:65173",
+            "CHEBI:8871"
+          ],
+          "enriched_nodes": [
+            "MONDO:0005469"
+          ],
+          "p_value": 7.451499487927692e-20,
+          "coalescence_method": "graph_enrichment"
+        },
+        {
+          "qg_id": "extra_qn_0",
+          "kg_id": [
+            "MONDO:0005469"
+          ]
+        }
+      ],
+      "edge_bindings": [
+        {
+          "qg_id": "ab",
+          "kg_id": "14403bd92938ce4daec86a4771bf62e5",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "ab",
+          "kg_id": "1f6d1af9c9790d9e764acbcefa529560",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "ab",
+          "kg_id": "45bb9997c8ac47225836c8e74cf91b5a",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "ab",
+          "kg_id": "f07c7b7ecfe8842148bd274046d16b91",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "ab",
+          "kg_id": "b10e8f04da87590a3f4594b55cb5f622",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "ab",
+          "kg_id": "43821d8754c5fd847b24ae5bff93cf0b",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "ab",
+          "kg_id": "25ca4674bccf3d3623ec99ddd401fef8",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "ab",
+          "kg_id": "f35fb52da54f92f60696a99e84bfa51a",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "-2663754149609806096",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "1917879541043216263",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "-8811129079244630924",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "3833623213098875228",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "6363292418905172663",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "-1757460190812366426",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "8485690120326003672",
+          "weight": 0.2679491924311228
+        },
+        {
+          "qg_id": "extra_qe_0",
+          "kg_id": "5988279711666690606",
+          "weight": 0.2679491924311228
+        }
+      ],
+      "score": 109.10848778735631
+    }
+  ]
+}

--- a/tests/test_score.py
+++ b/tests/test_score.py
@@ -3,7 +3,7 @@ import json
 from fastapi.testclient import TestClient
 from ranker.server import APP
 # this will load all the json test files into global objects to use in a test
-from .fixtures import weighted2,schizo
+from .fixtures import weighted2,schizo,treatsSchizophreniaw
 
 # start a client
 client = TestClient(APP)
@@ -28,4 +28,9 @@ def test_score(weighted2):
 def test_score_schizo(schizo):
     """Test that score() runs without errors."""
     response = client.post('/score', json={"message": schizo})
+    assert response.status_code == 200
+
+def test_score_schizo(treatsSchizophreniaw):
+    """Test that score() runs without errors."""
+    response = client.post('/score', json={"message": treatsSchizophreniaw})
     assert response.status_code == 200


### PR DESCRIPTION
There are two ways that sets can be handled in 0.9.2.  In a particular node binding, you can have:
```
{
qg_id: q
kg_id: k1
qg_id: q
kg_id: k2
}
```
Or
```
qg_id: q
kg_id: [k1,k2]
```

The code handled the former, but not the latter.  The new version handles both.