### PR TITLE
Lookup prefixes dynamically

### DIFF
--- a/ranker/modules/omnicorp_overlay.py
+++ b/ranker/modules/omnicorp_overlay.py
@@ -29,8 +29,8 @@ async def count_node_pmids(supporter, node, key, value, cache, kgraph):
         if cache and support_dict['omnicorp_article_count']:
             cache.set(key, support_dict)
     # add omnicorp_article_count to nodes in networkx graph
-    attribute = [{'type': 'omnicorp_article_count', 'value': support_dict['omnicorp_article_count']}]
-    kgraph[node]['attributes'] = attribute
+    attribute = {'type': 'EDAM:data_0006', 'name': 'omnicorp_article_count', 'value': support_dict['omnicorp_article_count']}
+    kgraph[node]['attributes'].append(attribute)
     #kgraph[node].update(support_dict)
 
 

--- a/ranker/modules/score.py
+++ b/ranker/modules/score.py
@@ -1,7 +1,5 @@
 """Rank."""
 from reasoner_pydantic import Response, Message
-
-from ranker.shared.util import flatten_semilist
 from ranker.shared.ranker_obj import Ranker
 
 

--- a/ranker/shared/neo4j_.py
+++ b/ranker/shared/neo4j_.py
@@ -1,0 +1,108 @@
+"""Neo4j lookup utilities."""
+from abc import ABC, abstractmethod
+from copy import deepcopy
+import json
+import logging
+from urllib.parse import urlparse
+
+import httpx
+from neo4j import GraphDatabase, basic_auth
+
+from messenger.shared.util import batches, flatten_semilist
+
+logger = logging.getLogger(__name__)
+
+
+class Neo4jDatabase():
+    """Neo4j database.
+
+    This is a thin wrapper that chooses whether to instantiate
+    a Bolt interface or an HTTP interface.
+    """
+
+    def __new__(cls, url=None, **kwargs):
+        """Generate database interface."""
+        scheme = urlparse(url).scheme
+        if scheme == 'http':
+            return HttpInterface(url=url, **kwargs)
+        elif scheme == 'bolt':
+            return BoltInterface(url=url, **kwargs)
+        else:
+            raise ValueError(f'Unsupported interface scheme "{scheme}"')
+
+    @abstractmethod
+    def run(self, statement, *args):
+        """Run statement."""
+        pass
+
+
+class Neo4jInterface(ABC):
+    """Abstract interface to Neo4j database."""
+
+    def __init__(self, url=None, credentials=None, **kwargs):
+        """Initialize."""
+        url = urlparse(url)
+        self.hostname = url.hostname
+        self.port = url.port
+        self.auth = (credentials['username'], credentials['password'])
+
+    @abstractmethod
+    def run(self, statement, *args):
+        """Run statement."""
+        pass
+
+
+class HttpInterface(Neo4jInterface):
+    """HTTP interface to Neo4j database."""
+
+    def __init__(self, **kwargs):
+        """Initialize."""
+        super().__init__(**kwargs)
+        self.url = f'http://{self.hostname}:{self.port}/db/data/transaction/commit'
+
+    async def arun(self, statement, *args):
+        """Run statement."""
+        async with httpx.AsyncClient(timeout=None) as client:
+            response = await client.post(
+                self.url,
+                auth=self.auth,
+                json={"statements": [{"statement": statement}]},
+            )
+        result = response.json()['results'][0]
+        result = [
+            dict(zip(result['columns'], datum['row']))
+            for datum in result['data']
+        ]
+        return result
+
+    def run(self, statement, *args):
+        """Run statement."""
+        response = httpx.post(
+            self.url,
+            auth=self.auth,
+            json={"statements": [{"statement": statement}]},
+        )
+        result = response.json()['results'][0]
+        result = [
+            dict(zip(result['columns'], datum['row']))
+            for datum in result['data']
+        ]
+        return result
+
+
+class BoltInterface(Neo4jInterface):
+    """Bolt interface to Neo4j database."""
+
+    def __init__(self, **kwargs):
+        """Initialize."""
+        super().__init__(**kwargs)
+        self.url = f'bolt://{self.hostname}:{self.port}'
+        self.driver = GraphDatabase.driver(
+            self.url,
+            auth=basic_auth(*self.auth)
+        )
+
+    def run(self, statement, *args):
+        """Run statement."""
+        with self.driver.session() as session:
+            return [dict(row) for row in session.run(statement)]

--- a/ranker/shared/omnicorp_postgres.py
+++ b/ranker/shared/omnicorp_postgres.py
@@ -20,7 +20,7 @@ class OmniCorp():
 
     def __init__(self):
         """Create and omnicorp service object."""
-        self.prefixes = self.get_prefixes()
+        self.prefixes = None
         self.pool = None
         self.nsingle = 0
         self.total_single_call = datetime.timedelta()
@@ -37,6 +37,7 @@ class OmniCorp():
             host=OMNICORP_HOST,
             port=OMNICORP_PORT,
         )
+        self.prefixes = await self.get_prefixes()
 
     async def close(self):
         """Close PostgreSQL connection."""

--- a/ranker/shared/omnicorp_postgres.py
+++ b/ranker/shared/omnicorp_postgres.py
@@ -51,7 +51,7 @@ class OmniCorp():
             "WHERE table_schema = 'omnicorp'"
         )
         async with self.pool.acquire() as conn:
-            rows = await conn.fetchrows(statement)
+            rows = await conn.fetch(statement)
         prefixes = [ row['table_name'] for row in rows ]
         return prefixes
 

--- a/ranker/shared/omnicorp_postgres.py
+++ b/ranker/shared/omnicorp_postgres.py
@@ -3,7 +3,7 @@ import datetime
 import os
 import logging
 import asyncpg
-from ranker.shared.util import get_curie_prefix
+from ranker.shared.util import get_postgres_curie_prefix
 
 logger = logging.getLogger(__name__)
 
@@ -20,21 +20,7 @@ class OmniCorp():
 
     def __init__(self):
         """Create and omnicorp service object."""
-        self.prefixes = set([
-            'UBERON',
-            'BSPO',
-            'PATO',
-            'GO',
-            'MONDO',
-            'HP',
-            'ENVO',
-            'OBI',
-            'CL',
-            'SO',
-            'CHEBI',
-            'HGNC',
-            'EFO',
-            'MESH'])
+        self.prefixes = self.get_prefixes()
         self.pool = None
         self.nsingle = 0
         self.total_single_call = datetime.timedelta()
@@ -57,10 +43,21 @@ class OmniCorp():
         logger.debug('Closing PostgreSQL connection pool...')
         await self.pool.close()
 
+    async def get_prefixes(self):
+        statement = (
+            "SELECT table_name\n"
+            "FROM information_schema.tables\n"
+            "WHERE table_schema = 'omnicorp'"
+        )
+        async with self.pool.acquire() as conn:
+            rows = await conn.fetchrows(statement)
+        prefixes = [ row['table_name'] for row in rows ]
+        return prefixes
+
     async def get_shared_pmids_count(self, node1, node2):
         """Get shared PMIDs."""
-        prefix1 = get_curie_prefix(node1)
-        prefix2 = get_curie_prefix(node2)
+        prefix1 = get_postgres_curie_prefix(node1)
+        prefix2 = get_postgres_curie_prefix(node2)
         if (
                 prefix1 not in self.prefixes or
                 prefix2 not in self.prefixes
@@ -84,12 +81,12 @@ class OmniCorp():
     async def count_pmids(self, node):
         """Count PMIDs and return result."""
         try:
-            if get_curie_prefix(node) not in self.prefixes:
+            if get_postgres_curie_prefix(node) not in self.prefixes:
                 return 0
         except:
             return 0
 
-        prefix = get_curie_prefix(node)
+        prefix = get_postgres_curie_prefix(node)
         start = datetime.datetime.now()
         statement = (
             f"SELECT COUNT(pubmedid) from omnicorp.{prefix}\n"

--- a/ranker/shared/qgraph_compiler.py
+++ b/ranker/shared/qgraph_compiler.py
@@ -1,0 +1,140 @@
+"""Tools for compiling QGraph into Cypher query."""
+
+
+def cypher_prop_string(value):
+    """Convert property value to cypher string representation."""
+    if isinstance(value, bool):
+        return str(value).lower()
+    elif isinstance(value, str):
+        return f"'{value}'"
+    else:
+        raise ValueError(f'Unsupported property type: {type(value).__name__}.')
+
+
+class NodeReference():
+    """Node reference object."""
+
+    def __init__(self, node, anonymous=False):
+        """Create a node reference."""
+        node = dict(node)
+        node_id = node.pop("id")
+        name = f'{node_id}' if not anonymous else ''
+        labels = node.pop('type', 'named_thing')
+        if not isinstance(labels, list):
+            labels = [labels]
+        props = {}
+
+        curie = node.pop("curie", None)
+        if curie is not None:
+            if isinstance(curie, str):
+                props['id'] = curie
+                filters = ''
+            elif isinstance(curie, list):
+                filters = []
+                for ci in curie:
+                    # generate curie-matching condition
+                    filters.append(f"{name}.id = '{ci}'")
+                # union curie-matching filters together
+                filters = ' OR '.join(filters)
+            else:
+                raise TypeError("Curie should be a string or list of strings.")
+        else:
+            filters = ''
+
+        node.pop('name', None)
+        node.pop('set', False)
+        props.update(node)
+
+        self.name = name
+        self.labels = labels
+        self.prop_string = ' {' + ', '.join([f"`{key}`: {cypher_prop_string(props[key])}" for key in props]) + '}'
+        self._filters = filters
+        if curie:
+            self._extras = f' USING INDEX {name}:{labels[0]}(id)'
+        else:
+            self._extras = ''
+        self._num = 0
+
+    def __str__(self):
+        """Return the cypher node reference."""
+        self._num += 1
+        if self._num == 1:
+            return f'{self.name}' + \
+                   ''.join(f':`{label}`' for label in self.labels) + \
+                   f'{self.prop_string}'
+        return self.name
+
+    @property
+    def filters(self):
+        """Return filters for the cypher node reference.
+
+        To be used in a WHERE clause following the MATCH clause.
+        """
+        if self._num == 1:
+            return self._filters
+        else:
+            return ''
+
+    @property
+    def extras(self):
+        """Return extras for the cypher node reference.
+
+        To be appended to the MATCH clause.
+        """
+        if self._num == 1:
+            return self._extras
+        else:
+            return ''
+
+
+class EdgeReference():
+    """Edge reference object."""
+
+    def __init__(self, edge, anonymous=False):
+        """Create an edge reference."""
+        name = f'{edge["id"]}' if not anonymous else ''
+        label = edge['type'] if 'type' in edge else None
+
+        if 'type' in edge and edge['type'] is not None:
+            if isinstance(edge['type'], str):
+                label = edge['type']
+                filters = ''
+            elif isinstance(edge['type'], list):
+                filters = []
+                for predicate in edge['type']:
+                    filters.append(f'type({name}) = "{predicate}"')
+                filters = ' OR '.join(filters)
+                label = None
+        else:
+            label = None
+            filters = ''
+
+        self.name = name
+        self.label = label
+        self._num = 0
+        self._filters = filters
+        has_type = 'type' in edge and edge['type']
+        self.directed = edge.get('directed', has_type)
+
+    def __str__(self):
+        """Return the cypher edge reference."""
+        self._num += 1
+        if self._num == 1:
+            innards = f'{self.name}{":" + self.label if self.label else ""}'
+        else:
+            innards = self.name
+        if self.directed:
+            return f'-[{innards}]->'
+        else:
+            return f'-[{innards}]-'
+
+    @property
+    def filters(self):
+        """Return filters for the cypher node reference.
+
+        To be used in a WHERE clause following the MATCH clause.
+        """
+        if self._num == 1:
+            return self._filters
+        else:
+            return ''

--- a/ranker/shared/util.py
+++ b/ranker/shared/util.py
@@ -31,3 +31,11 @@ def get_curie_prefix(curie):
     if ':' not in curie:
         raise ValueError('Curies ought to contain a colon')
     return curie.upper().split(':')[0]
+
+def get_postgres_curie_prefix(curie):
+    """The representation in postgres moves things to lowercase, and replaces . with _"""
+    if ':' not in curie:
+        raise ValueError('Curies ought to contain a colon')
+    prefix = curie.lower().split(':')
+    prefix = '_'.join(prefix.split('.'))
+    return prefix

--- a/ranker/shared/util.py
+++ b/ranker/shared/util.py
@@ -37,5 +37,5 @@ def get_postgres_curie_prefix(curie):
     if ':' not in curie:
         raise ValueError('Curies ought to contain a colon')
     prefix = curie.lower().split(':')
-    prefix = '_'.join(prefix.split('.'))
+    prefix = '_'.join(prefix[0].split('.'))
     return prefix

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,4 +12,4 @@ uvloop==0.14.0
 numpy==1.19.4
 httptools==0.1.1
 git+https://github.com/ranking-agent/reasoner#egg=reasoner
-git+https://github.com/ranking-agent/reasoner-pydantic@v1.0#egg=reasoner-pydantic
+git+https://github.com/ranking-agent/reasoner-pydantic#egg=reasoner-pydantic

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -6,5 +6,5 @@ python-dotenv==0.14.0
 psycopg2==2.8.6
 tox==3.20.1
 git+https://github.com/ranking-agent/reasoner#egg=reasoner
-git+https://github.com/TranslatorSRI/reasoner-pydantic@v1.0#egg=reasoner-pydantic
+git+https://github.com/TranslatorSRI/reasoner-pydantic#egg=reasoner-pydantic
 git+https://github.com/TranslatorSRI/reasoner-converter#egg=reasoner-converter


### PR DESCRIPTION
Addresses https://github.com/ranking-agent/aragorn-ranker/issues/12

One thing that appears to be happening is that we don't keep the paper counts for nodes in the cache, so those always go to postgres (should update this too)

The postgres omnicorp checked the prefixes against an internal list, but that list needs to be updated regularly.  This version checks postgres and just pulls what tables are there, rather than hard coding it.

It also handles that some prefixes have "." in them, which have to be converted to "_" as a table name.

This hasn't been fully tested, can you take a look @PhillipsOwen ?