### PR TITLE
Bugfixes to weighting

### DIFF
--- a/ranker/modules/omnicorp_overlay.py
+++ b/ranker/modules/omnicorp_overlay.py
@@ -78,10 +78,11 @@ async def count_shared_pmids(
     uid = str(uuid4())
 
     kgraph['edges'].update({uid: {
-        'predicate': 'biolink:correlated_with',
+        'predicate': 'biolink:occurs_together_in_literature_with',
         'attributes': [
             {'original_attribute_name': 'num_publications', 'attribute_type_id': 'biolink:has_count', 'value_type_id': 'EDAM:data_0006', 'value': support_edge},
-            {'original_attribute_name': 'publications', 'attribute_type_id': 'biolink:publications', 'value_type_id': 'EDAM:data_0006', 'value': []},
+            #If we're returning a count, then returning an empty list here is gibberish, and causes an error in weighting.
+            #{'original_attribute_name': 'publications', 'attribute_type_id': 'biolink:publications', 'value_type_id': 'EDAM:data_0006', 'value': []},
             {
                 "attribute_type_id": "biolink:original_knowledge_source",  # the ‘key’*
                 "value": "infores:aragorn-ranker-ara",

--- a/ranker/modules/weight_correctness.py
+++ b/ranker/modules/weight_correctness.py
@@ -176,11 +176,9 @@ async def query(
                 if num_publications == 0:
                     num_publications = len(publications)
 
-                # now the nicer cleaner version when we have publications as an actual array
-                # edge_pubs = edge.get('num_publications', len(edge.get('publications', [])))
-                if edges[edge].get('predicate') == 'literature_co-occurrence':
-                    subject_pubs = int(node_pubs[edge['subject']])
-                    object_pubs = int(node_pubs[edge['object']])
+                if edges[edge].get('predicate') == 'biolink:occurs_together_in_literature_with':
+                    subject_pubs = int(node_pubs[edges[edge]['subject']])
+                    object_pubs = int(node_pubs[edges[edge]['object']])
 
                     cov = (num_publications / all_pubs) - (subject_pubs / all_pubs) * (object_pubs / all_pubs)
                     cov = max((cov, 0.0))

--- a/ranker/server.py
+++ b/ranker/server.py
@@ -12,7 +12,7 @@ from fastapi.openapi.utils import get_openapi
 from reasoner_pydantic import Response as PDResponse
 
 # set the app version
-APP_VERSION = '2.0.8'
+APP_VERSION = '2.0.9'
 
 APP = FastAPI(title='ARAGORN Ranker', version=APP_VERSION)
 

--- a/tests/InputJson_1.2/acet.json
+++ b/tests/InputJson_1.2/acet.json
@@ -1,0 +1,327 @@
+{
+    "message": {
+        "query_graph": {
+            "nodes": {
+                "n0": {
+                    "ids": [
+                        "CHEMBL.COMPOUND:CHEMBL112"
+                    ],
+                    "categories": null,
+                    "is_set": false,
+                    "constraints": []
+                },
+                "n1": {
+                    "ids": [
+                        "NCBIGene:54600",
+                        "NCBIGene:5743"
+                    ],
+                    "categories": [
+                        "biolink:Gene"
+                    ],
+                    "is_set": false,
+                    "constraints": []
+                }
+            },
+            "edges": {
+                "e01": {
+                    "subject": "n0",
+                    "object": "n1",
+                    "predicates": [
+                        "biolink:molecularly_interacts_with"
+                    ],
+                    "constraints": []
+                }
+            }
+        },
+        "knowledge_graph": {
+            "nodes": {
+                "PUBCHEM.COMPOUND:1983": {
+                    "categories": [
+                        "biolink:Entity",
+                        "biolink:NamedThing",
+                        "biolink:PhysicalEssenceOrOccurrent",
+                        "biolink:PhysicalEssence",
+                        "biolink:SmallMolecule",
+                        "biolink:MolecularEntity",
+                        "biolink:ChemicalEntity"
+                    ],
+                    "name": "Acetaminophen",
+                    "attributes": [
+                        {
+                            "attribute_type_id": "biolink:same_as",
+                            "value": [
+                                "PUBCHEM.COMPOUND:1983",
+                                "CHEMBL.COMPOUND:CHEMBL112",
+                                "UNII:362O9ITL9D",
+                                "CHEBI:46195",
+                                "DRUGBANK:DB00316",
+                                "MESH:D000082",
+                                "CAS:103-90-2",
+                                "CAS:360769-21-7",
+                                "DrugCentral:52",
+                                "GTOPDB:5239",
+                                "HMDB:HMDB0001859",
+                                "KEGG.COMPOUND:C06804",
+                                "INCHIKEY:RZVAJINKPMORJF-UHFFFAOYSA-N"
+                            ],
+                            "value_type_id": "metatype:uriorcurie",
+                            "original_attribute_name": "equivalent_identifiers",
+                            "value_url": null,
+                            "attribute_source": null,
+                            "description": null,
+                            "attributes": null
+                        },
+                        {
+                            "attribute_type_id": "biolink:aggregator_knowledge_source",
+                            "value": "infores:automat-hetio",
+                            "value_type_id": "biolink:InformationResource",
+                            "original_attribute_name": "biolink:aggregator_knowledge_source",
+                            "value_url": null,
+                            "attribute_source": null,
+                            "description": null,
+                            "attributes": null
+                        }
+                    ]
+                },
+                "NCBIGene:54600": {
+                    "categories": [
+                        "biolink:Entity",
+                        "biolink:NamedThing",
+                        "biolink:BiologicalEntity",
+                        "biolink:GeneOrGeneProduct",
+                        "biolink:Gene",
+                        "biolink:MacromolecularMachineMixin"
+                    ],
+                    "name": "UGT1A9",
+                    "attributes": [
+                        {
+                            "attribute_type_id": "biolink:same_as",
+                            "value": [
+                                "NCBIGene:54600",
+                                "ENSEMBL:ENSG00000241119",
+                                "HGNC:12541",
+                                "OMIM:606434",
+                                "UMLS:C1421333"
+                            ],
+                            "value_type_id": "metatype:uriorcurie",
+                            "original_attribute_name": "equivalent_identifiers",
+                            "value_url": null,
+                            "attribute_source": null,
+                            "description": null,
+                            "attributes": null
+                        },
+                        {
+                            "attribute_type_id": "biolink:aggregator_knowledge_source",
+                            "value": "infores:automat-hetio",
+                            "value_type_id": "biolink:InformationResource",
+                            "original_attribute_name": "biolink:aggregator_knowledge_source",
+                            "value_url": null,
+                            "attribute_source": null,
+                            "description": null,
+                            "attributes": null
+                        }
+                    ]
+                },
+                "NCBIGene:5743": {
+                    "categories": [
+                        "biolink:Entity",
+                        "biolink:NamedThing",
+                        "biolink:BiologicalEntity",
+                        "biolink:GeneOrGeneProduct",
+                        "biolink:Gene",
+                        "biolink:MacromolecularMachineMixin"
+                    ],
+                    "name": "PTGS2",
+                    "attributes": [
+                        {
+                            "attribute_type_id": "biolink:same_as",
+                            "value": [
+                                "NCBIGene:5743",
+                                "ENSEMBL:ENSG00000073756",
+                                "HGNC:9605",
+                                "OMIM:600262",
+                                "UMLS:C1367485"
+                            ],
+                            "value_type_id": "metatype:uriorcurie",
+                            "original_attribute_name": "equivalent_identifiers",
+                            "value_url": null,
+                            "attribute_source": null,
+                            "description": null,
+                            "attributes": null
+                        },
+                        {
+                            "attribute_type_id": "biolink:aggregator_knowledge_source",
+                            "value": "infores:automat-hetio",
+                            "value_type_id": "biolink:InformationResource",
+                            "original_attribute_name": "biolink:aggregator_knowledge_source",
+                            "value_url": null,
+                            "attribute_source": null,
+                            "description": null,
+                            "attributes": null
+                        }
+                    ]
+                }
+            },
+            "edges": {
+                "5d733470c9480666ddad898cd5edaf63": {
+                    "subject": "PUBCHEM.COMPOUND:1983",
+                    "object": "NCBIGene:54600",
+                    "predicate": "biolink:molecularly_interacts_with",
+                    "attributes": [
+                        {
+                            "attribute_type_id": "biolink:primary_knowledge_source",
+                            "value": "infores:hetio",
+                            "value_type_id": "biolink:InformationResource",
+                            "original_attribute_name": "biolink:primary_knowledge_source",
+                            "value_url": null,
+                            "attribute_source": null,
+                            "description": null,
+                            "attributes": null
+                        },
+                        {
+                            "attribute_type_id": "biolink:Attribute",
+                            "value": [
+                                "DrugBank (enzyme)"
+                            ],
+                            "value_type_id": "EDAM:data_0006",
+                            "original_attribute_name": "hetio_source",
+                            "value_url": null,
+                            "attribute_source": null,
+                            "description": null,
+                            "attributes": null
+                        },
+                        {
+                            "attribute_type_id": "biolink:relation",
+                            "value": "RO:0002436",
+                            "value_type_id": "EDAM:data_0006",
+                            "original_attribute_name": "relation",
+                            "value_url": null,
+                            "attribute_source": null,
+                            "description": null,
+                            "attributes": null
+                        },
+                        {
+                            "attribute_type_id": "biolink:aggregator_knowledge_source",
+                            "value": "infores:automat-hetio",
+                            "value_type_id": "biolink:InformationResource",
+                            "original_attribute_name": "biolink:aggregator_knowledge_source",
+                            "value_url": null,
+                            "attribute_source": null,
+                            "description": null,
+                            "attributes": null
+                        },
+                        {
+                            "attribute_type_id": "biolink:aggregator_knowledge_source",
+                            "value": "infores:aragorn"
+                        }
+                    ]
+                },
+                "3b21e7d518f10066eb3edb9375c92b84": {
+                    "subject": "PUBCHEM.COMPOUND:1983",
+                    "object": "NCBIGene:5743",
+                    "predicate": "biolink:molecularly_interacts_with",
+                    "attributes": [
+                        {
+                            "attribute_type_id": "biolink:primary_knowledge_source",
+                            "value": "infores:hetio",
+                            "value_type_id": "biolink:InformationResource",
+                            "original_attribute_name": "biolink:primary_knowledge_source",
+                            "value_url": null,
+                            "attribute_source": null,
+                            "description": null,
+                            "attributes": null
+                        },
+                        {
+                            "attribute_type_id": "biolink:Attribute",
+                            "value": [
+                                "DrugBank (target)",
+                                "DrugCentral (ChEMBL)"
+                            ],
+                            "value_type_id": "EDAM:data_0006",
+                            "original_attribute_name": "hetio_source",
+                            "value_url": null,
+                            "attribute_source": null,
+                            "description": null,
+                            "attributes": null
+                        },
+                        {
+                            "attribute_type_id": "biolink:relation",
+                            "value": "RO:0002436",
+                            "value_type_id": "EDAM:data_0006",
+                            "original_attribute_name": "relation",
+                            "value_url": null,
+                            "attribute_source": null,
+                            "description": null,
+                            "attributes": null
+                        },
+                        {
+                            "attribute_type_id": "biolink:aggregator_knowledge_source",
+                            "value": "infores:automat-hetio",
+                            "value_type_id": "biolink:InformationResource",
+                            "original_attribute_name": "biolink:aggregator_knowledge_source",
+                            "value_url": null,
+                            "attribute_source": null,
+                            "description": null,
+                            "attributes": null
+                        },
+                        {
+                            "attribute_type_id": "biolink:aggregator_knowledge_source",
+                            "value": "infores:aragorn"
+                        }
+                    ]
+                }
+            }
+        },
+        "results": [
+            {
+                "node_bindings": {
+                    "n0": [
+                        {
+                            "id": "PUBCHEM.COMPOUND:1983",
+                            "qnode_id": "PUBCHEM.COMPOUND:1983"
+                        }
+                    ],
+                    "n1": [
+                        {
+                            "id": "NCBIGene:54600",
+                            "qnode_id": "NCBIGene:54600"
+                        }
+                    ]
+                },
+                "edge_bindings": {
+                    "e01": [
+                        {
+                            "id": "5d733470c9480666ddad898cd5edaf63",
+                            "attributes": null
+                        }
+                    ]
+                }
+            },
+            {
+                "node_bindings": {
+                    "n0": [
+                        {
+                            "id": "PUBCHEM.COMPOUND:1983",
+                            "qnode_id": "PUBCHEM.COMPOUND:1983"
+                        }
+                    ],
+                    "n1": [
+                        {
+                            "id": "NCBIGene:5743",
+                            "qnode_id": "NCBIGene:5743"
+                        }
+                    ]
+                },
+                "edge_bindings": {
+                    "e01": [
+                        {
+                            "id": "3b21e7d518f10066eb3edb9375c92b84",
+                            "attributes": null
+                        }
+                    ]
+                }
+            }
+        ]
+    },
+    "logs": []
+}

--- a/tests/test_omnicorp_overlay.py
+++ b/tests/test_omnicorp_overlay.py
@@ -39,3 +39,4 @@ def test_omnicorp_overlay_with_set(property_coalesce):
 
     assert(len(answer['message']['results'][0]['edge_bindings']) == 1)
     assert(len(answer['message']['results'][0]['edge_bindings']['ab']) == 10)
+


### PR DESCRIPTION
1. Updating the biolink predicate being used.  This is a bit tricky b/c the current predicate in 2.2.7 is actually `biolink:co-occurs_in_literature_with` which fails to trapi validate.  The predicate being used here is a future one (2.2.8) but it's not going to cause any trouble.
2. Omnicorp was returning both a num_publications and a publications: [] attribute.  The empty publications was causing trouble in weighting.
3. Getting the normalization values was completely wrong.