### PR TITLE
Modify r_graph to consider sets based on node bindings

### DIFF
--- a/ranker/shared/ranker_obj.py
+++ b/ranker/shared/ranker_obj.py
@@ -135,6 +135,12 @@ class Ranker:
         rnodes = set()
         redges = []
 
+        # Checks if multiple nodes share node bindings 
+        rgraph_sets = [
+            node
+            for node in answer['node_bindings']
+            if len(answer['node_bindings'][node]) > 1 
+        ]
         # get list of nodes, and knode_map
         knode_map = defaultdict(set)
         for nb in answer['node_bindings']:
@@ -151,7 +157,7 @@ class Ranker:
                 rnodes.add(rnode_id)
                 knode_map[knode_id].add(rnode_id)
 
-                if qnode_id in self.leaf_sets:
+                if qnode_id in rgraph_sets:
                     anchor_id = (f'{qnode_id}_anchor', '')
                     rnodes.add(anchor_id)
                     redges.append({


### PR DESCRIPTION
This updates the result graph creation to make the anchor nodes based on the number of nodes with the same node bindings instead of the query graph. The query graph would not always align with the results due to the answer coalescer.

#55 