### PR TITLE
Fixed bug where rgraph contains edges between nodes with the same qedge_id

### DIFF
--- a/tests/InputJson_1.2/overlapping_set.json
+++ b/tests/InputJson_1.2/overlapping_set.json
@@ -1,0 +1,147 @@
+{
+  "message": {
+    "query_graph": {
+      "nodes": {
+        "n0": {
+          "categories": ["biolink:Gene"]
+        },
+        "n1": {
+          "categories": ["biolink:Gene"],
+          "is_set": "True"
+        }
+      },
+      "edges": {
+        "e01": {
+          "subject": "n0",
+          "object": "n1"
+        }
+      }
+    },
+    "knowledge_graph": {
+      "nodes": {
+        "knode_0": {
+          "name": "Gene:x"
+        },
+        "knode_1": {
+          "name": "Gene:y"
+        },
+        "knode_2": {
+          "name": "Gene:z"
+        }
+      },
+      "edges": {
+        "edge_0": {
+          "subject": "knode_0",
+          "object": "knode_0",
+          "predicate": "biolink:related_to"
+        },
+        "edge_1": {
+          "subject": "knode_0",
+          "object": "knode_1",
+          "predicate": "biolink:related_to"
+        },
+        "edge_2": {
+          "subject": "knode_0",
+          "object": "knode_2",
+          "predicate": "biolink:related_to"
+        },
+        "support_edge": {
+          "subject": "knode_0",
+          "object": "knode_0",
+          "predicate": "biolink:occurs_together_in_literature_with",
+          "attributes": [
+            {
+              "attribute_type_id": "biolink:has_count",
+              "value": 1,
+              "value_type_id": "EDAM:data_0006",
+              "original_attribute_name": "num_publications",
+              "value_url": null,
+              "attribute_source": null,
+              "description": null,
+              "attributes": null
+            },
+            {
+              "attribute_type_id": "biolink:original_knowledge_source",
+              "value": "infores:aragorn-ranker-ara",
+              "value_type_id": "biolink:InformationResource",
+              "original_attribute_name": null,
+              "value_url": null,
+              "attribute_source": "infores:aragorn-ranker-ara",
+              "description": null,
+              "attributes": null
+            }
+          ]
+        }
+      }
+    },
+    "results": [
+      {
+        "node_bindings": {
+          "n0": [
+            {
+              "id": "knode_0"
+            }
+          ],
+          "n1": [
+            {
+              "id": "knode_0"
+            },
+            {
+              "id": "knode_1"
+            },
+            {
+              "id": "knode_2"
+            }
+          ]
+        },
+        "edge_bindings": {
+          "e01": [
+            {
+              "id": "edge_1",
+              "attributes": [
+                {
+                  "original_attribute_name": "weight",
+                  "attribute_type_id": "biolink:has_numeric_value",
+                  "value": 2,
+                  "value_type_id": "EDAM:data_1669"
+                }
+              ]
+            },
+            {
+              "id": "edge_2",
+              "attributes": [
+                {
+                  "original_attribute_name": "weight",
+                  "attribute_type_id": "biolink:has_numeric_value",
+                  "value": 1,
+                  "value_type_id": "EDAM:data_1669"
+                }
+              ]
+            }
+          ],
+          "s01": [
+            {
+              "id": "support_edge",
+              "attributes": [
+                {
+                  "original_attribute_name": "weight",
+                  "attribute_type_id": "biolink:has_numeric_value",
+                  "value": 1,
+                  "value_type_id": "EDAM:data_1669",
+                  "attributes": [
+                    {
+                      "original_attribute_name": "aragorn_weight_source",
+                      "attribute_type_id": "biolink:has_qualitative_value",
+                      "value": "infores:aragorn-ranker-ara",
+                      "value_type_id": "biolink:InformationResource"
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      }
+    ]
+  }
+}

--- a/tests/test_rgraph.py
+++ b/tests/test_rgraph.py
@@ -1,0 +1,13 @@
+from ranker.shared.ranker_obj import Ranker
+from .fixtures import overlapping_set
+
+def test_rgraph_edges_between_same_qnode(overlapping_set):
+    message =  overlapping_set['message']
+    ranker = Ranker(message)
+
+    for answer in message['results']:
+        _, redges = ranker.get_rgraph(answer)
+
+        for redge in redges:
+            # Assert that the qnode_id of each endpoint are different
+            assert redge['subject'][0] != redge['object'][0]


### PR DESCRIPTION
The existing logic to generate rgraph edges creates invalid edges when adjacent qnodes are bound to the same CURIE.

Consider this onehop:
```
Query Graph:
 _________                   _________
|         |                 |         |
| Disease | --related_to--> | Disease |
|_________|       e0        |_________|
    n0                          n1    

Knowledge Graph:
 ___________                   ___________
|           |                 |           |
| Disease:0 | --related_to--> | Disease:1 |
|___________|    kedge_0      |___________|       

Result:
"node_bindings": {
    "n0": [{ "id": "Disease:0"}],
    "n1": [{ "id": "Disease:0"}, { "id": "Disease:1"}],
},
"edge_bindings": {
    "e0": { "id": "kedge_0" }
}
```
In this case, the current code generates multiple edges in the ranking graph:
```
("n0", "Disease:0") -> ("n1", "Disease:1") # Valid
("n1", "Disease:0") -> ("n1", "Disease:1") # Invalid
```