### PR TITLE
Added rnode merging to fix node high-scoring sets problem

### DIFF
--- a/tests/InputJson_1.2/overlapping_set.json
+++ b/tests/InputJson_1.2/overlapping_set.json
@@ -3,7 +3,8 @@
     "query_graph": {
       "nodes": {
         "n0": {
-          "categories": ["biolink:Gene"]
+          "categories": ["biolink:Gene"],
+          "is_set": "True"
         },
         "n1": {
           "categories": ["biolink:Gene"],
@@ -80,6 +81,9 @@
           "n0": [
             {
               "id": "knode_0"
+            },
+            {
+              "id": "knode_1"
             }
           ],
           "n1": [

--- a/tests/test_rgraph.py
+++ b/tests/test_rgraph.py
@@ -10,4 +10,15 @@ def test_rgraph_edges_between_same_qnode(overlapping_set):
 
         for redge in redges:
             # Assert that the qnode_id of each endpoint are different
-            assert redge['subject'][0] != redge['object'][0]
+            rnodes = redge['rnodes']
+            assert min(rnodes) != max(rnodes)
+
+def test_rgraph_rnodes_match_qnodes(overlapping_set):
+    message =  overlapping_set['message']
+    ranker = Ranker(message)
+
+    for answer in message['results']:
+        rnodes, _ = ranker.get_rgraph(answer)
+
+        assert sorted(rnodes) == sorted(answer['node_bindings'].keys())
+


### PR DESCRIPTION
This commit changes how the ranker graph is created in the case of qnodes bound to multiple knodes. This change fixes the problem where results with sets score significantly higher than results without sets. (It turns out that increasing the number of nodes in a set always increases result score)

Currently, the ranker graph is a weighted version of the question graph (plus support edges), except when qnodes were bound to a set of knodes. With this change, we aggregate nodes bound to the same qnode, making ranker graph a weighted question graph even in the case of sets. To compute the weights of each qedge, we aggregate multiple weights. There are several one-to-many relationships between the given weights and the qedges.

1. A single qedge can be bound to multiple kedges.
2. A single kedge can have weights from multiple sources.
3. Weights of a single source can come from multiple attributes.

We repeatedly merge the weights from the attribute level up to the qedge level using `merge_weights` to assign each qedge a single weight.